### PR TITLE
Parser/Lexer naming style

### DIFF
--- a/IronVelocity.Tests/Parser/AdditiveExpressionTests.cs
+++ b/IronVelocity.Tests/Parser/AdditiveExpressionTests.cs
@@ -13,7 +13,7 @@ namespace IronVelocity.Tests.Parser
             var right = "$right";
             var input = $"{left} {@operator} {right}";
 
-            ParseBinaryExpressionTest(input, left, right, operatorTokenKind, x => x.additive_expression());
+            ParseBinaryExpressionTest(input, left, right, operatorTokenKind, x => x.additiveExpression());
         }
     }
 }

--- a/IronVelocity.Tests/Parser/AdditiveExpressionTests.cs
+++ b/IronVelocity.Tests/Parser/AdditiveExpressionTests.cs
@@ -5,8 +5,8 @@ namespace IronVelocity.Tests.Parser
 {
     public class AdditiveExpressionTests : ParserTestBase
     {
-        [TestCase("+",  VelocityLexer.PLUS)]
-        [TestCase("-",  VelocityLexer.MINUS)]
+        [TestCase("+",  VelocityLexer.Plus)]
+        [TestCase("-",  VelocityLexer.Minus)]
         public void ParseBinaryAdditiveExpressionTests(string @operator, int operatorTokenKind)
         {
             var left = "$left";

--- a/IronVelocity.Tests/Parser/AndExpressionTests.cs
+++ b/IronVelocity.Tests/Parser/AndExpressionTests.cs
@@ -11,14 +11,14 @@ namespace IronVelocity.Tests.Parser
         [TestCase(" false and true ", "false", "true")]
         public void ParseBinaryAndExpressionTests(string input, string left, string right)
         {
-            ParseBinaryExpressionTest(input, left, right, VelocityLexer.AND, x => x.andExpression());
+            ParseBinaryExpressionTest(input, left, right, VelocityLexer.And, x => x.andExpression());
         }
 
         [Test]
         public void ParseTernaryAndExpressionTests()
         {
             var input = "$a && $b and $c";
-            ParseTernaryExpressionWithEqualPrecedenceTest(input, VelocityLexer.AND, VelocityLexer.AND, x => x.andExpression());
+            ParseTernaryExpressionWithEqualPrecedenceTest(input, VelocityLexer.And, VelocityLexer.And, x => x.andExpression());
         }
     }
 }

--- a/IronVelocity.Tests/Parser/AndExpressionTests.cs
+++ b/IronVelocity.Tests/Parser/AndExpressionTests.cs
@@ -11,14 +11,14 @@ namespace IronVelocity.Tests.Parser
         [TestCase(" false and true ", "false", "true")]
         public void ParseBinaryAndExpressionTests(string input, string left, string right)
         {
-            ParseBinaryExpressionTest(input, left, right, VelocityLexer.AND, x => x.and_expression());
+            ParseBinaryExpressionTest(input, left, right, VelocityLexer.AND, x => x.andExpression());
         }
 
         [Test]
         public void ParseTernaryAndExpressionTests()
         {
             var input = "$a && $b and $c";
-            ParseTernaryExpressionWithEqualPrecedenceTest(input, VelocityLexer.AND, VelocityLexer.AND, x => x.and_expression());
+            ParseTernaryExpressionWithEqualPrecedenceTest(input, VelocityLexer.AND, VelocityLexer.AND, x => x.andExpression());
         }
     }
 }

--- a/IronVelocity.Tests/Parser/AssignmentTests.cs
+++ b/IronVelocity.Tests/Parser/AssignmentTests.cs
@@ -13,7 +13,7 @@ namespace IronVelocity.Tests.Parser
         [TestCase("$x = $y.stuff(123)", "$x", "$y.stuff(123)")]
         public void ParseAssignmentExpression(string input, string left, string right)
         {
-            ParseBinaryExpressionTest(input, left, right, VelocityParser.ASSIGN, x => x.assignment());
+            ParseBinaryExpressionTest(input, left, right, VelocityParser.Assign, x => x.assignment());
         }
     }
 }

--- a/IronVelocity.Tests/Parser/CustomDirectives.cs
+++ b/IronVelocity.Tests/Parser/CustomDirectives.cs
@@ -20,7 +20,7 @@ namespace IronVelocity.Tests.Parser
             var result = Parse(input, x => x.customDirective());
 
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.DIRECTIVE_NAME()?.GetText(), Is.EqualTo("test"));
+            Assert.That(result.DirectiveName()?.GetText(), Is.EqualTo("test"));
             Assert.That(result.block(), Is.Null);
         }
 
@@ -32,7 +32,7 @@ namespace IronVelocity.Tests.Parser
             var result = Parse(input, x => x.customDirective());
 
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.DIRECTIVE_NAME()?.GetText(), Is.EqualTo("custom"));
+            Assert.That(result.DirectiveName()?.GetText(), Is.EqualTo("custom"));
 
             Assert.That(result.directiveArguments(), Is.Not.Null);
             Assert.That(result.block(), Is.Null);
@@ -46,7 +46,7 @@ namespace IronVelocity.Tests.Parser
             var result = Parse(input, ParseBlockDirective);
 
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.DIRECTIVE_NAME()?.GetText(), Is.EqualTo("multiLine"));
+            Assert.That(result.DirectiveName()?.GetText(), Is.EqualTo("multiLine"));
             Assert.That(result.directiveArguments(), Is.Not.Null);
             Assert.That(result.block(), Is.Not.Null);
         }
@@ -58,7 +58,7 @@ namespace IronVelocity.Tests.Parser
             var result = Parse(input, ParseBlockDirective);
 
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.DIRECTIVE_NAME()?.GetText(), Is.EqualTo("multiLine"));
+            Assert.That(result.DirectiveName()?.GetText(), Is.EqualTo("multiLine"));
             Assert.That(result.block(), Is.Not.Null);
             Assert.That(result.directiveArguments(), Is.Not.Null);
         }
@@ -70,7 +70,7 @@ namespace IronVelocity.Tests.Parser
             var result = Parse(input, ParseBlockDirective);
 
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.DIRECTIVE_NAME()?.GetText(), Is.EqualTo("multiLine"));
+            Assert.That(result.DirectiveName()?.GetText(), Is.EqualTo("multiLine"));
             Assert.That(result.block(), Is.Not.Null);
             Assert.That(result.directiveArguments(), Is.Not.Null);
         }

--- a/IronVelocity.Tests/Parser/CustomDirectives.cs
+++ b/IronVelocity.Tests/Parser/CustomDirectives.cs
@@ -6,10 +6,10 @@ namespace IronVelocity.Tests.Parser
     public class CustomDirectives : ParserTestBase
     {
 
-        private VelocityParser.Custom_directiveContext ParseBlockDirective(VelocityParser parser)
+        private VelocityParser.CustomDirectiveContext ParseBlockDirective(VelocityParser parser)
         {
             parser.BlockDirectives = new[] { "multiLine" };
-            return parser.custom_directive();
+            return parser.customDirective();
         } 
 
         [Test]
@@ -17,7 +17,7 @@ namespace IronVelocity.Tests.Parser
         {
             var input = "#test";
 
-            var result = Parse(input, x => x.custom_directive());
+            var result = Parse(input, x => x.customDirective());
 
             Assert.That(result, Is.Not.Null);
             Assert.That(result.DIRECTIVE_NAME()?.GetText(), Is.EqualTo("test"));
@@ -29,12 +29,12 @@ namespace IronVelocity.Tests.Parser
         [TestCase("#custom( 123 456 )")]
         public void ShouldParseLineCustomDirectiveWithArguments(string input)
         {
-            var result = Parse(input, x => x.custom_directive());
+            var result = Parse(input, x => x.customDirective());
 
             Assert.That(result, Is.Not.Null);
             Assert.That(result.DIRECTIVE_NAME()?.GetText(), Is.EqualTo("custom"));
 
-            Assert.That(result.directive_arguments(), Is.Not.Null);
+            Assert.That(result.directiveArguments(), Is.Not.Null);
             Assert.That(result.block(), Is.Null);
         }
 
@@ -47,7 +47,7 @@ namespace IronVelocity.Tests.Parser
 
             Assert.That(result, Is.Not.Null);
             Assert.That(result.DIRECTIVE_NAME()?.GetText(), Is.EqualTo("multiLine"));
-            Assert.That(result.directive_arguments(), Is.Not.Null);
+            Assert.That(result.directiveArguments(), Is.Not.Null);
             Assert.That(result.block(), Is.Not.Null);
         }
 
@@ -60,7 +60,7 @@ namespace IronVelocity.Tests.Parser
             Assert.That(result, Is.Not.Null);
             Assert.That(result.DIRECTIVE_NAME()?.GetText(), Is.EqualTo("multiLine"));
             Assert.That(result.block(), Is.Not.Null);
-            Assert.That(result.directive_arguments(), Is.Not.Null);
+            Assert.That(result.directiveArguments(), Is.Not.Null);
         }
 
         [Test]
@@ -72,7 +72,7 @@ namespace IronVelocity.Tests.Parser
             Assert.That(result, Is.Not.Null);
             Assert.That(result.DIRECTIVE_NAME()?.GetText(), Is.EqualTo("multiLine"));
             Assert.That(result.block(), Is.Not.Null);
-            Assert.That(result.directive_arguments(), Is.Not.Null);
+            Assert.That(result.directiveArguments(), Is.Not.Null);
         }
 
         [Test]

--- a/IronVelocity.Tests/Parser/DirectiveArgumentListTests.cs
+++ b/IronVelocity.Tests/Parser/DirectiveArgumentListTests.cs
@@ -20,19 +20,19 @@ namespace IronVelocity.Tests.Parser
         public void ParseDirectiveArgumentList(int argumentCount, string input)
         {
             input = $"({input})";
-            var result = Parse(input, x => x.directive_arguments(), VelocityLexer.ARGUMENTS);
+            var result = Parse(input, x => x.directiveArguments(), VelocityLexer.ARGUMENTS);
 
             Assert.That(result, Is.Not.Null);
             Assert.That(result.GetFullText(), Is.EqualTo(input.Trim()));
 
-            var arguments = result.directive_argument();
+            var arguments = result.directiveArgument();
             Assert.That(arguments, Has.Length.EqualTo(argumentCount));
         }
 
         [TestCase("1,1")]
         public void ParseInvalidDirectiveArgumentList(string input)
         {
-            ParseShouldProduceError(input, x => x.directive_arguments(), VelocityLexer.ARGUMENTS);
+            ParseShouldProduceError(input, x => x.directiveArguments(), VelocityLexer.ARGUMENTS);
         }
     }
 }

--- a/IronVelocity.Tests/Parser/EqualityExpressionTests.cs
+++ b/IronVelocity.Tests/Parser/EqualityExpressionTests.cs
@@ -5,10 +5,10 @@ namespace IronVelocity.Tests.Parser
 {
     public class EqualityExpressionTests : ParserTestBase
     {
-        [TestCase("$x==$y", "$x", "$y", VelocityLexer.EQUAL)]
-        [TestCase(" false != true ", "false", "true", VelocityLexer.NOTEQUAL)]
-        [TestCase(" false eq true ", "false", "true", VelocityLexer.EQUAL)]
-        [TestCase("${x}ne${y} ", "${x}", "${y}", VelocityLexer.NOTEQUAL)]
+        [TestCase("$x==$y", "$x", "$y", VelocityLexer.Equal)]
+        [TestCase(" false != true ", "false", "true", VelocityLexer.NotEqual)]
+        [TestCase(" false eq true ", "false", "true", VelocityLexer.Equal)]
+        [TestCase("${x}ne${y} ", "${x}", "${y}", VelocityLexer.NotEqual)]
         public void ParseBinaryEqualityExpressionTests(string input, string left, string right, int operatorTokenKind)
         {
             ParseBinaryExpressionTest(input, left, right, operatorTokenKind, x => x.equalityExpression());
@@ -18,7 +18,7 @@ namespace IronVelocity.Tests.Parser
         public void ParseTernaryEqualityExpressionTests()
         {
             var input = "$a == $b ne $c";
-            ParseTernaryExpressionWithEqualPrecedenceTest(input, VelocityLexer.EQUAL, VelocityLexer.NOTEQUAL, x => x.equalityExpression());
+            ParseTernaryExpressionWithEqualPrecedenceTest(input, VelocityLexer.Equal, VelocityLexer.NotEqual, x => x.equalityExpression());
         }
     }
 }

--- a/IronVelocity.Tests/Parser/EqualityExpressionTests.cs
+++ b/IronVelocity.Tests/Parser/EqualityExpressionTests.cs
@@ -11,14 +11,14 @@ namespace IronVelocity.Tests.Parser
         [TestCase("${x}ne${y} ", "${x}", "${y}", VelocityLexer.NOTEQUAL)]
         public void ParseBinaryEqualityExpressionTests(string input, string left, string right, int operatorTokenKind)
         {
-            ParseBinaryExpressionTest(input, left, right, operatorTokenKind, x => x.equality_expression());
+            ParseBinaryExpressionTest(input, left, right, operatorTokenKind, x => x.equalityExpression());
         }
 
         [Test]
         public void ParseTernaryEqualityExpressionTests()
         {
             var input = "$a == $b ne $c";
-            ParseTernaryExpressionWithEqualPrecedenceTest(input, VelocityLexer.EQUAL, VelocityLexer.NOTEQUAL, x => x.equality_expression());
+            ParseTernaryExpressionWithEqualPrecedenceTest(input, VelocityLexer.EQUAL, VelocityLexer.NOTEQUAL, x => x.equalityExpression());
         }
     }
 }

--- a/IronVelocity.Tests/Parser/IfTests.cs
+++ b/IronVelocity.Tests/Parser/IfTests.cs
@@ -12,7 +12,7 @@ namespace IronVelocity.Tests.Parser
         [TestCase("#if( !(true) )#end")]
         public void ShouldParseBasicIf(string input)
         {
-            var result = Parse(input, x => x.if_block());
+            var result = Parse(input, x => x.ifBlock());
 
             Assert.That(result, Is.Not.Null);
         }

--- a/IronVelocity.Tests/Parser/InterpolatedStringTests.cs
+++ b/IronVelocity.Tests/Parser/InterpolatedStringTests.cs
@@ -10,7 +10,7 @@ namespace IronVelocity.Tests.Parser
         [TestCase("\"'\"")]
         public void ParseInterpolatedStringLiteral(string input)
         {
-            var result = Parse(input, x => x.interpolated_string(), VelocityLexer.ARGUMENTS);
+            var result = Parse(input, x => x.interpolatedString(), VelocityLexer.ARGUMENTS);
 
             Assert.That(result, Is.Not.Null);
             Assert.That(result.GetText(), Is.EqualTo(input));

--- a/IronVelocity.Tests/Parser/MultiplicativeExpressionTests.cs
+++ b/IronVelocity.Tests/Parser/MultiplicativeExpressionTests.cs
@@ -5,9 +5,9 @@ namespace IronVelocity.Tests.Parser
 {
     public class Multiplicative : ParserTestBase
     {
-        [TestCase("*",  VelocityLexer.MULTIPLY)]
-        [TestCase("/", VelocityLexer.DIVIDE)]
-        [TestCase("%", VelocityLexer.MODULO)]
+        [TestCase("*",  VelocityLexer.Multiply)]
+        [TestCase("/", VelocityLexer.Divide)]
+        [TestCase("%", VelocityLexer.Modulo)]
         public void ParseBinaryMultiplicitiveExpressionTests(string @operator, int operatorTokenKind)
         {
             var left = "$left";

--- a/IronVelocity.Tests/Parser/MultiplicativeExpressionTests.cs
+++ b/IronVelocity.Tests/Parser/MultiplicativeExpressionTests.cs
@@ -14,7 +14,7 @@ namespace IronVelocity.Tests.Parser
             var right = "$right";
             var input = $"{left} {@operator} {right}";
 
-            ParseBinaryExpressionTest(input, left, right, operatorTokenKind, x => x.multiplicative_expression());
+            ParseBinaryExpressionTest(input, left, right, operatorTokenKind, x => x.multiplicativeExpression());
         }
     }
 }

--- a/IronVelocity.Tests/Parser/OrExpressionTests.cs
+++ b/IronVelocity.Tests/Parser/OrExpressionTests.cs
@@ -11,14 +11,14 @@ namespace IronVelocity.Tests.Parser
         [TestCase(" false or true ", "false", "true")]
         public void ParseBinaryOrExpressionTests(string input, string left, string right)
         {
-            ParseBinaryExpressionTest(input, left, right, VelocityLexer.OR, x => x.expression());
+            ParseBinaryExpressionTest(input, left, right, VelocityLexer.Or, x => x.expression());
         }
 
         [Test]
         public void ParseTernaryOrExpressionTests()
         {
             var input = "$a || $b or $c";
-            ParseTernaryExpressionWithEqualPrecedenceTest(input, VelocityLexer.OR, VelocityLexer.OR, x=> x.expression());
+            ParseTernaryExpressionWithEqualPrecedenceTest(input, VelocityLexer.Or, VelocityLexer.Or, x=> x.expression());
         }
 
     }

--- a/IronVelocity.Tests/Parser/PrimaryExpressionTests.cs
+++ b/IronVelocity.Tests/Parser/PrimaryExpressionTests.cs
@@ -10,13 +10,13 @@ namespace IronVelocity.Tests.Parser
         [TestCase("7.4", typeof(VelocityParser.FloatContext))]
         [TestCase("true", typeof(VelocityParser.BooleanContext))]
         [TestCase("'string'", typeof(VelocityParser.StringContext))]
-        [TestCase("\"interpolated\"", typeof(VelocityParser.Interpolated_stringContext))]
+        [TestCase("\"interpolated\"", typeof(VelocityParser.InterpolatedStringContext))]
         [TestCase("[]", typeof(VelocityParser.ListContext))]
         [TestCase("[1..3]", typeof(VelocityParser.RangeContext))]
-        [TestCase("(1+2)", typeof(VelocityParser.Parenthesised_expressionContext))]
+        [TestCase("(1+2)", typeof(VelocityParser.ParenthesisedExpressionContext))]
         public void ParsePrimaryExpression(string input, Type parsedNodeType)
         {
-            var result = Parse(input, x => x.primary_expression(), VelocityLexer.ARGUMENTS);
+            var result = Parse(input, x => x.primaryExpression(), VelocityLexer.ARGUMENTS);
 
             Assert.That(result, Is.Not.Null);
             Assert.That(result.GetText(), Is.EqualTo(input));

--- a/IronVelocity.Tests/Parser/RangeTests.cs
+++ b/IronVelocity.Tests/Parser/RangeTests.cs
@@ -24,13 +24,13 @@ namespace IronVelocity.Tests.Parser
 
         }
 
-        private VelocityParser.Primary_expressionContext GetPrimaryExpression(VelocityParser.ExpressionContext expression)
+        private VelocityParser.PrimaryExpressionContext GetPrimaryExpression(VelocityParser.ExpressionContext expression)
         {
             IParseTree tree = expression;
 
             while (tree != null)
             {
-                var primaryExpression = tree as VelocityParser.Primary_expressionContext;
+                var primaryExpression = tree as VelocityParser.PrimaryExpressionContext;
                 if (primaryExpression != null)
                     return primaryExpression;
 

--- a/IronVelocity.Tests/Parser/ReferenceTests.cs
+++ b/IronVelocity.Tests/Parser/ReferenceTests.cs
@@ -38,7 +38,7 @@ namespace IronVelocity.Tests.Parser
             var variable = reference?.referenceBody()?.variable();
             Assert.That(variable, Is.Not.Null);
 
-            Assert.That(variable.IDENTIFIER().GetText(), Is.EqualTo(variableName));
+            Assert.That(variable.Identifier().GetText(), Is.EqualTo(variableName));
         }
 
         [TestCase("$foo.dog", "dog")]
@@ -53,7 +53,7 @@ namespace IronVelocity.Tests.Parser
 
             var property = reference.referenceBody()?.propertyInvocation().Single();
             Assert.That(property, Is.Not.Null);
-            Assert.That(property.IDENTIFIER()?.GetText(), Is.EqualTo(propertyName));
+            Assert.That(property.Identifier()?.GetText(), Is.EqualTo(propertyName));
         }
 
 
@@ -69,7 +69,7 @@ namespace IronVelocity.Tests.Parser
 
             var method = reference.referenceBody()?.methodInvocation().Single();
             Assert.That(method, Is.Not.Null);
-            Assert.That(method.IDENTIFIER()?.GetText(), Is.EqualTo(methodName));
+            Assert.That(method.Identifier()?.GetText(), Is.EqualTo(methodName));
             Assert.That(method.argument_list(), Is.Not.Null);
         }
 

--- a/IronVelocity.Tests/Parser/ReferenceTests.cs
+++ b/IronVelocity.Tests/Parser/ReferenceTests.cs
@@ -35,7 +35,7 @@ namespace IronVelocity.Tests.Parser
             Assert.That(reference, Is.Not.Null);
             Assert.That(reference.GetText(), Is.EqualTo(input));
 
-            var variable = reference?.reference_body()?.variable();
+            var variable = reference?.referenceBody()?.variable();
             Assert.That(variable, Is.Not.Null);
 
             Assert.That(variable.IDENTIFIER().GetText(), Is.EqualTo(variableName));
@@ -51,7 +51,7 @@ namespace IronVelocity.Tests.Parser
             Assert.That(reference, Is.Not.Null);
             Assert.That(reference.GetText(), Is.EqualTo(input));
 
-            var property = reference.reference_body()?.property_invocation().Single();
+            var property = reference.referenceBody()?.propertyInvocation().Single();
             Assert.That(property, Is.Not.Null);
             Assert.That(property.IDENTIFIER()?.GetText(), Is.EqualTo(propertyName));
         }
@@ -67,7 +67,7 @@ namespace IronVelocity.Tests.Parser
             Assert.That(reference, Is.Not.Null);
             Assert.That(reference.GetText(), Is.EqualTo(input));
 
-            var method = reference.reference_body()?.method_invocation().Single();
+            var method = reference.referenceBody()?.methodInvocation().Single();
             Assert.That(method, Is.Not.Null);
             Assert.That(method.IDENTIFIER()?.GetText(), Is.EqualTo(methodName));
             Assert.That(method.argument_list(), Is.Not.Null);

--- a/IronVelocity.Tests/Parser/RelationalExpressionTests.cs
+++ b/IronVelocity.Tests/Parser/RelationalExpressionTests.cs
@@ -5,14 +5,14 @@ namespace IronVelocity.Tests.Parser
 {
     public class RelationalExpressionTests : ParserTestBase
     {
-        [TestCase(">",  VelocityLexer.GREATERTHAN)]
-        [TestCase("<",  VelocityLexer.LESSTHAN)]
-        [TestCase(">=",  VelocityLexer.GREATERTHANOREQUAL)]
-        [TestCase("<=",  VelocityLexer.LESSTHANOREQUAL)]
-        [TestCase("gt",  VelocityLexer.GREATERTHAN)]
-        [TestCase("lt",  VelocityLexer.LESSTHAN)]
-        [TestCase("ge",  VelocityLexer.GREATERTHANOREQUAL)]
-        [TestCase("le",  VelocityLexer.LESSTHANOREQUAL)]
+        [TestCase(">",  VelocityLexer.GreaterThan)]
+        [TestCase("<",  VelocityLexer.LessThan)]
+        [TestCase(">=",  VelocityLexer.GreaterThanOrEqual)]
+        [TestCase("<=",  VelocityLexer.LessThanOrEqual)]
+        [TestCase("gt",  VelocityLexer.GreaterThan)]
+        [TestCase("lt",  VelocityLexer.LessThan)]
+        [TestCase("ge",  VelocityLexer.GreaterThanOrEqual)]
+        [TestCase("le",  VelocityLexer.LessThanOrEqual)]
         public void ParseBinaryRelationalExpressionTests(string @operator, int operatorTokenKind)
         {
             var left = "$left";

--- a/IronVelocity.Tests/Parser/RelationalExpressionTests.cs
+++ b/IronVelocity.Tests/Parser/RelationalExpressionTests.cs
@@ -19,7 +19,7 @@ namespace IronVelocity.Tests.Parser
             var right = "$right";
             var input = $"{left} {@operator} {right}";
 
-            ParseBinaryExpressionTest(input, left, right, operatorTokenKind, x => x.relational_expression());
+            ParseBinaryExpressionTest(input, left, right, operatorTokenKind, x => x.relationalExpression());
         }
     }
 }

--- a/IronVelocity.Tests/Parser/Samples.cs
+++ b/IronVelocity.Tests/Parser/Samples.cs
@@ -12,7 +12,7 @@ namespace IronVelocity.Tests.Parser
         };
 
         /// <summary>
-        /// Some examples of text that starts like a reference, but isn't as there is no IDENTIFIER.
+        /// Some examples of text that starts like a reference, but isn't as there is no Identifier.
         /// These patterns have historically caused lots of problems 
         /// </summary>
         public static IEnumerable<string> ReferenceLikeText { get; } = new[]

--- a/IronVelocity.Tests/Parser/SetDirective.cs
+++ b/IronVelocity.Tests/Parser/SetDirective.cs
@@ -14,7 +14,7 @@ namespace IronVelocity.Tests.Parser
         [TestCase("#set($output = ($input.ToString(123, 'hello')))")]
         public void ParseSetDirective(string input)
         {
-            var result = Parse(input, x => x.set_directive());
+            var result = Parse(input, x => x.setDirective());
 
             Assert.That(result, Is.Not.Null);
             Assert.That(result.GetFullText(), Is.EqualTo(input));

--- a/IronVelocity.Tests/Parser/UnaryExpressionTests.cs
+++ b/IronVelocity.Tests/Parser/UnaryExpressionTests.cs
@@ -5,7 +5,7 @@ namespace IronVelocity.Tests.Parser
 {
     public class UnaryExpressionTests : ParserTestBase
     {
-        [TestCase("!",  VelocityLexer.EXCLAMATION)]
+        [TestCase("!",  VelocityLexer.Exclamation)]
         public void ParseUnaryExpressionTests(string @operator, int operatorTokenKind)
         {
             var target= "$target";

--- a/IronVelocity.Tests/Parser/UnaryExpressionTests.cs
+++ b/IronVelocity.Tests/Parser/UnaryExpressionTests.cs
@@ -11,7 +11,7 @@ namespace IronVelocity.Tests.Parser
             var target= "$target";
             var input = @operator + target;
 
-            var parsed = Parse(input, x => x.unary_expression(), VelocityLexer.ARGUMENTS);
+            var parsed = Parse(input, x => x.unaryExpression(), VelocityLexer.ARGUMENTS);
             Assert.That(parsed, Is.Not.Null);
             Assert.That(parsed.GetText(), Is.EqualTo(input));
             Assert.That(parsed.ChildCount, Is.EqualTo(2));

--- a/IronVelocity/Parser/AntlrToExpressionTreeCompiler.cs
+++ b/IronVelocity/Parser/AntlrToExpressionTreeCompiler.cs
@@ -60,13 +60,13 @@ namespace IronVelocity.Parser
 
                 switch (token.Type)
                 {
-                    case VelocityLexer.WHITESPACE:
-                    case VelocityLexer.NEWLINE:
+                    case VelocityLexer.Whitespace:
+                    case VelocityLexer.Newline:
                         goto default;
-                    case VelocityLexer.ESCAPED_DOLLAR:
+                    case VelocityLexer.EscapedDollar:
                         _textBuffer.Append('$');
                         break;
-                    case VelocityLexer.ESCAPED_HASH:
+                    case VelocityLexer.EscapedHash:
                         _textBuffer.Append('#');
                         break;
                     default:
@@ -83,8 +83,8 @@ namespace IronVelocity.Parser
             return new ReferenceExpression(
                 value: Visit(context.referenceBody()),
                 raw: context.GetFullText(),
-                isSilent: context.EXCLAMATION() != null,
-                isFormal: context.LEFT_CURLEY() != null
+                isSilent: context.Exclamation() != null,
+                isFormal: context.LeftCurley() != null
                 );
         }
 
@@ -100,7 +100,7 @@ namespace IronVelocity.Parser
                 var property = innerContext as VelocityParser.PropertyInvocationContext;
                 if (property != null)
                 {
-                    var name = property.IDENTIFIER().GetText();
+                    var name = property.Identifier().GetText();
                     if (ReflectionHelper.IsConstantType(result))
                     {
                         //TODO: include debug info
@@ -119,7 +119,7 @@ namespace IronVelocity.Parser
                     var method = innerContext as VelocityParser.MethodInvocationContext;
                     if (method != null)
                     {
-                        var name = method.IDENTIFIER().GetText();
+                        var name = method.Identifier().GetText();
                         var args = VisitMany(method.argument_list().expression());
                         if (ReflectionHelper.IsConstantType(result) && args.All(ReflectionHelper.IsConstantType))
                         {
@@ -146,7 +146,7 @@ namespace IronVelocity.Parser
         public Expression VisitVariable([NotNull] VelocityParser.VariableContext context)
         {
             Expression result;
-            var name = context.IDENTIFIER().GetText();
+            var name = context.Identifier().GetText();
             if (!_variableCache.TryGetValue(name, out result))
             {
                 object global = null;
@@ -336,19 +336,19 @@ namespace IronVelocity.Parser
             MathematicalOperation operation;
             switch (operatorKind)
             {
-                case VelocityLexer.PLUS:
+                case VelocityLexer.Plus:
                     operation = MathematicalOperation.Add;
                     break;
-                case VelocityLexer.MINUS:
+                case VelocityLexer.Minus:
                     operation = MathematicalOperation.Subtract;
                     break;
-                case VelocityLexer.MULTIPLY:
+                case VelocityLexer.Multiply:
                     operation = MathematicalOperation.Multiply;
                     break;
-                case VelocityLexer.DIVIDE:
+                case VelocityLexer.Divide:
                     operation = MathematicalOperation.Divide;
                     break;
-                case VelocityLexer.MODULO:
+                case VelocityLexer.Modulo:
                     operation = MathematicalOperation.Modulo;
                     break;
                 default:
@@ -381,22 +381,22 @@ namespace IronVelocity.Parser
             ComparisonOperation operation;
             switch (operatorKind)
             {
-                case VelocityLexer.LESSTHAN:
+                case VelocityLexer.LessThan:
                     operation = ComparisonOperation.LessThan;
                     break;
-                case VelocityLexer.GREATERTHAN:
+                case VelocityLexer.GreaterThan:
                     operation = ComparisonOperation.GreaterThan;
                     break;
-                case VelocityLexer.LESSTHANOREQUAL:
+                case VelocityLexer.LessThanOrEqual:
                     operation = ComparisonOperation.LessThanOrEqual;
                     break;
-                case VelocityLexer.GREATERTHANOREQUAL:
+                case VelocityLexer.GreaterThanOrEqual:
                     operation = ComparisonOperation.GreaterThanOrEqual;
                     break;
-                case VelocityLexer.EQUAL:
+                case VelocityLexer.Equal:
                     operation = ComparisonOperation.Equal;
                     break;
-                case VelocityLexer.NOTEQUAL:
+                case VelocityLexer.NotEqual:
                     operation = ComparisonOperation.NotEqual;
                     break;
                 default:
@@ -434,7 +434,7 @@ namespace IronVelocity.Parser
 
         public Expression VisitCustomDirective([NotNull] VelocityParser.CustomDirectiveContext context)
         {
-            var name = context.DIRECTIVE_NAME().GetText();
+            var name = context.DirectiveName().GetText();
             var handler = _customDirectives.SingleOrDefault(x => x.Name == name);
 
             if (handler == null)
@@ -459,7 +459,7 @@ namespace IronVelocity.Parser
         }
 
         public Expression VisitDirectiveWord([NotNull] VelocityParser.DirectiveWordContext context)
-            => new DirectiveWord(context.IDENTIFIER().GetText());
+            => new DirectiveWord(context.Identifier().GetText());
 
         private SourceInfo GetSourceInfo(ParserRuleContext context)
         {

--- a/IronVelocity/Parser/AntlrToExpressionTreeCompiler.cs
+++ b/IronVelocity/Parser/AntlrToExpressionTreeCompiler.cs
@@ -44,7 +44,7 @@ namespace IronVelocity.Parser
                 );
         }
 
-        public Expression VisitBlock_comment([NotNull] VelocityParser.Block_commentContext context) => Constants.EmptyExpression;
+        public Expression VisitBlockComment([NotNull] VelocityParser.BlockCommentContext context) => Constants.EmptyExpression;
 
         public Expression VisitComment([NotNull] VelocityParser.CommentContext context) => Constants.EmptyExpression;
 
@@ -81,14 +81,14 @@ namespace IronVelocity.Parser
         public Expression VisitReference([NotNull] VelocityParser.ReferenceContext context)
         {
             return new ReferenceExpression(
-                value: Visit(context.reference_body()),
+                value: Visit(context.referenceBody()),
                 raw: context.GetFullText(),
                 isSilent: context.EXCLAMATION() != null,
                 isFormal: context.LEFT_CURLEY() != null
                 );
         }
 
-        public Expression VisitReference_body([NotNull] VelocityParser.Reference_bodyContext context)
+        public Expression VisitReferenceBody([NotNull] VelocityParser.ReferenceBodyContext context)
         {
             var result = VisitVariable(context.variable());
 
@@ -97,7 +97,7 @@ namespace IronVelocity.Parser
             for (int i = 1; i < further.Length; i++)
             {
                 var innerContext = further[i];
-                var property = innerContext as VelocityParser.Property_invocationContext;
+                var property = innerContext as VelocityParser.PropertyInvocationContext;
                 if (property != null)
                 {
                     var name = property.IDENTIFIER().GetText();
@@ -116,7 +116,7 @@ namespace IronVelocity.Parser
                 }
                 else
                 {
-                    var method = innerContext as VelocityParser.Method_invocationContext;
+                    var method = innerContext as VelocityParser.MethodInvocationContext;
                     if (method != null)
                     {
                         var name = method.IDENTIFIER().GetText();
@@ -164,7 +164,7 @@ namespace IronVelocity.Parser
             return result;
         }
 
-        public Expression VisitPrimary_expression([NotNull] VelocityParser.Primary_expressionContext context) => Visit(context.GetRuleContext<ParserRuleContext>(0));
+        public Expression VisitPrimaryExpression([NotNull] VelocityParser.PrimaryExpressionContext context) => Visit(context.GetRuleContext<ParserRuleContext>(0));
 
         public Expression VisitInteger([NotNull] VelocityParser.IntegerContext context)
         {
@@ -199,7 +199,7 @@ namespace IronVelocity.Parser
             return Expression.Constant(unquotedText);
         }
 
-        public Expression VisitInterpolated_string([NotNull] VelocityParser.Interpolated_stringContext context)
+        public Expression VisitInterpolatedString([NotNull] VelocityParser.InterpolatedStringContext context)
         {
             //TODO: Should dictionary strings be handled in the lexer/parser?
             // Yes - would be more efficient.
@@ -266,7 +266,7 @@ namespace IronVelocity.Parser
             return visitedExpressions;
         }
 
-        public Expression VisitSet_directive([NotNull] VelocityParser.Set_directiveContext context)
+        public Expression VisitSetDirective([NotNull] VelocityParser.SetDirectiveContext context)
             => VisitAssignment(context.assignment());
 
         public Expression VisitAssignment([NotNull] VelocityParser.AssignmentContext context)
@@ -284,14 +284,14 @@ namespace IronVelocity.Parser
             return new SetDirective(left, right, GetSourceInfo(context));
         }
 
-        public Expression VisitIf_block([NotNull] VelocityParser.If_blockContext context)
+        public Expression VisitIfBlock([NotNull] VelocityParser.IfBlockContext context)
         {
-            var elseBlock = context.if_else_block();
+            var elseBlock = context.ifElseBlock();
             Expression falseContent = elseBlock == null
                 ? Constants.EmptyExpression
                 : Visit(elseBlock.block());
 
-            var elseIfBlocks = context.GetRuleContexts<VelocityParser.If_elseif_blockContext>();
+            var elseIfBlocks = context.GetRuleContexts<VelocityParser.IfElseifBlockContext>();
             for (int i = elseIfBlocks.Length - 1; i >= 0; i--)
             {
                 var elseIf = elseIfBlocks[i];
@@ -309,7 +309,7 @@ namespace IronVelocity.Parser
 
 
 
-        public Expression VisitUnary_expression([NotNull] VelocityParser.Unary_expressionContext context)
+        public Expression VisitUnaryExpression([NotNull] VelocityParser.UnaryExpressionContext context)
         {
             if (context.ChildCount == 1)
                 return Visit(context.GetChild(0));
@@ -318,10 +318,10 @@ namespace IronVelocity.Parser
             return Expression.Not(VelocityExpressions.CoerceToBoolean(target));
         }
 
-        public Expression VisitMultiplicative_expression([NotNull] VelocityParser.Multiplicative_expressionContext context)
+        public Expression VisitMultiplicativeExpression([NotNull] VelocityParser.MultiplicativeExpressionContext context)
             => VisitMathematicalExpression(context);
 
-        public Expression VisitAdditive_expression([NotNull] VelocityParser.Additive_expressionContext context)
+        public Expression VisitAdditiveExpression([NotNull] VelocityParser.AdditiveExpressionContext context)
             => VisitMathematicalExpression(context);
 
         private Expression VisitMathematicalExpression(ParserRuleContext context)
@@ -362,10 +362,10 @@ namespace IronVelocity.Parser
             return new MathematicalExpression(left, right, sourceInfo, operation);
         }
 
-        public Expression VisitRelational_expression([NotNull] VelocityParser.Relational_expressionContext context)
+        public Expression VisitRelationalExpression([NotNull] VelocityParser.RelationalExpressionContext context)
             => VisitComparisonExpression(context);
 
-        public Expression VisitEquality_expression([NotNull] VelocityParser.Equality_expressionContext context)
+        public Expression VisitEqualityExpression([NotNull] VelocityParser.EqualityExpressionContext context)
             => VisitComparisonExpression(context);
 
         private Expression VisitComparisonExpression(ParserRuleContext context)
@@ -413,26 +413,26 @@ namespace IronVelocity.Parser
         public Expression VisitExpression([NotNull] VelocityParser.ExpressionContext context)
         {
             if (context.ChildCount == 1)
-                return Visit(context.and_expression());
+                return Visit(context.andExpression());
 
             var left = VelocityExpressions.CoerceToBoolean(Visit(context.expression()));
-            var right = VelocityExpressions.CoerceToBoolean(Visit(context.and_expression()));
+            var right = VelocityExpressions.CoerceToBoolean(Visit(context.andExpression()));
 
             return Expression.OrElse(left, right);
         }
 
-        public Expression VisitAnd_expression([NotNull] VelocityParser.And_expressionContext context)
+        public Expression VisitAndExpression([NotNull] VelocityParser.AndExpressionContext context)
         {
             if (context.ChildCount == 1)
-                return Visit(context.equality_expression());
+                return Visit(context.equalityExpression());
 
-            var left = VelocityExpressions.CoerceToBoolean(Visit(context.and_expression()));
-            var right = VelocityExpressions.CoerceToBoolean(Visit(context.equality_expression()));
+            var left = VelocityExpressions.CoerceToBoolean(Visit(context.andExpression()));
+            var right = VelocityExpressions.CoerceToBoolean(Visit(context.equalityExpression()));
 
             return Expression.AndAlso(left, right);
         }
 
-        public Expression VisitCustom_directive([NotNull] VelocityParser.Custom_directiveContext context)
+        public Expression VisitCustomDirective([NotNull] VelocityParser.CustomDirectiveContext context)
         {
             var name = context.DIRECTIVE_NAME().GetText();
             var handler = _customDirectives.SingleOrDefault(x => x.Name == name);
@@ -440,7 +440,7 @@ namespace IronVelocity.Parser
             if (handler == null)
                 return new UnrecognisedDirective(name, context.GetFullText());
 
-            var args = VisitMany(context.directive_arguments()?.directive_argument());
+            var args = VisitMany(context.directiveArguments()?.directiveArgument());
 
             var body = handler.IsBlockDirective
                 ? VisitBlock(context.block())
@@ -450,15 +450,15 @@ namespace IronVelocity.Parser
         }
 
 
-        public Expression VisitDirective_argument([NotNull] VelocityParser.Directive_argumentContext context)
+        public Expression VisitDirectiveArgument([NotNull] VelocityParser.DirectiveArgumentContext context)
         {
             var arg = context.expression();
             return arg == null
-                ? VisitDirective_word(context.directive_word())
+                ? VisitDirectiveWord(context.directiveWord())
                 : VisitExpression(arg);
         }
 
-        public Expression VisitDirective_word([NotNull] VelocityParser.Directive_wordContext context)
+        public Expression VisitDirectiveWord([NotNull] VelocityParser.DirectiveWordContext context)
             => new DirectiveWord(context.IDENTIFIER().GetText());
 
         private SourceInfo GetSourceInfo(ParserRuleContext context)
@@ -478,22 +478,22 @@ namespace IronVelocity.Parser
 
 
 
-        public Expression VisitIf_else_block([NotNull] VelocityParser.If_else_blockContext context)
+        public Expression VisitIfElseBlock([NotNull] VelocityParser.IfElseBlockContext context)
         {
             throw new NotImplementedException();
         }
 
-        public Expression VisitIf_elseif_block([NotNull] VelocityParser.If_elseif_blockContext context)
+        public Expression VisitIfElseifBlock([NotNull] VelocityParser.IfElseifBlockContext context)
         {
             throw new NotImplementedException();
         }
 
-        public Expression VisitProperty_invocation([NotNull] VelocityParser.Property_invocationContext context)
+        public Expression VisitPropertyInvocation([NotNull] VelocityParser.PropertyInvocationContext context)
         {
             throw new NotImplementedException();
         }
 
-        public Expression VisitMethod_invocation([NotNull] VelocityParser.Method_invocationContext context)
+        public Expression VisitMethodInvocation([NotNull] VelocityParser.MethodInvocationContext context)
         {
             throw new NotImplementedException();
         }
@@ -513,10 +513,10 @@ namespace IronVelocity.Parser
             throw new NotImplementedException();
         }
 
-        public Expression VisitParenthesised_expression([NotNull] VelocityParser.Parenthesised_expressionContext context)
+        public Expression VisitParenthesisedExpression([NotNull] VelocityParser.ParenthesisedExpressionContext context)
             => Visit(context.expression());
 
-        public Expression VisitDirective_arguments([NotNull] VelocityParser.Directive_argumentsContext context)
+        public Expression VisitDirectiveArguments([NotNull] VelocityParser.DirectiveArgumentsContext context)
         {
             throw new InvalidOperationException();
         }

--- a/IronVelocity/Parser/VelocityLexer.g4
+++ b/IronVelocity/Parser/VelocityLexer.g4
@@ -112,7 +112,7 @@ RightParenthesis : ')' -> popMode ;
 True : 'true' ;
 False : 'false' ;
 Number : NUMERIC_CHAR+ ;
-Dot : '.' -> type(Dot) ;
+Dot7 : '.' -> type(Dot) ;
 String : '\'' ~('\'' | '\r' | '\n' )* '\'' ;
 InterpolatedString : '"' ~('"' | '\r' | '\n' )* '"' ;
 Dollar7 : '$' -> type(Dollar) ;

--- a/IronVelocity/Parser/VelocityLexer.g4
+++ b/IronVelocity/Parser/VelocityLexer.g4
@@ -18,37 +18,37 @@ fragment WHITESPACE_TEXT : WHITESPACE_CHAR+ ;
 //===================================
 // Default mode used for parsing text
 // Moves to the HASH_SEEN or DOLLAR_SEEN states upon seeing '$' or '#' respectively
-TEXT : ~('$'| '#' | ' ' | '\t' | '\r' | '\n' | '\\' )+ ;
-DOLLAR : '$' ->  mode(DOLLAR_SEEN) ;
-HASH : '#' -> mode(HASH_SEEN) ;
-WHITESPACE:  WHITESPACE_TEXT ;
-NEWLINE : '\r' | '\n' | '\r\n' ;
-ESCAPED_DOLLAR: '\\'+ '$' ;
-ESCAPED_HASH: '\\'+ '#' ;
-LONE_ESCAPE : '\\' ;
+Text : ~('$'| '#' | ' ' | '\t' | '\r' | '\n' | '\\' )+ ;
+Dollar : '$' ->  mode(DOLLAR_SEEN) ;
+Hash : '#' -> mode(HASH_SEEN) ;
+Whitespace:  WHITESPACE_TEXT ;
+Newline : '\r' | '\n' | '\r\n' ;
+EscapedDollar: '\\'+ '$' ;
+EscapedHash: '\\'+ '#' ;
+LoneEscape : '\\' ;
 
 //===================================
 // The mode is for when a hash has been seen in a location that allows text so
 // the parser can distinguish between a textual '#', comments and directives
 mode HASH_SEEN ;
 
-SINGLE_LINE_COMMENT : '#' ~('\r' | '\n')* -> type(COMMENT), mode(DEFAULT_MODE);
+SingleLineComment : '#' ~('\r' | '\n')* -> type(COMMENT), mode(DEFAULT_MODE);
 //Need to switch to default mode before pushing so that when the the matching end tag pops, we end back in text mode.
-BLOCK_COMMENT_START : '*' -> mode(DEFAULT_MODE), pushMode(BLOCK_COMMENT) ;
-SET : 'set' -> mode(DIRECTIVE_ARGUMENTS) ;
-IF : 'if' -> mode(DIRECTIVE_ARGUMENTS) ;
-ELSEIF : 'elseif' -> mode(DIRECTIVE_ARGUMENTS);
-ELSE : 'else' -> mode(DEFAULT_MODE) ;
-END : 'end' -> mode(DEFAULT_MODE) ;
-DIRECTIVE_NAME : DIRECTIVE_TEXT -> mode(DIRECTIVE_ARGUMENTS);
-TEXT_FALLBACK2 : -> type(TRANSITION), channel(HIDDEN), mode(DEFAULT_MODE) ;
+BlockCommentStart : '*' -> mode(DEFAULT_MODE), pushMode(BLOCK_COMMENT) ;
+Set : 'set' -> mode(DIRECTIVE_ARGUMENTS) ;
+If : 'if' -> mode(DIRECTIVE_ARGUMENTS) ;
+ElseIf : 'elseif' -> mode(DIRECTIVE_ARGUMENTS);
+Else : 'else' -> mode(DEFAULT_MODE) ;
+End : 'end' -> mode(DEFAULT_MODE) ;
+DirectiveName : DIRECTIVE_TEXT -> mode(DIRECTIVE_ARGUMENTS);
+TextFallback2 : -> type(TRANSITION), channel(HIDDEN), mode(DEFAULT_MODE) ;
 
 mode DIRECTIVE_ARGUMENTS ;
 
-//TODO: Including spaces in LEFT_PARENTHESIS is a bit of a hack
-WHITESPACE2A:  WHITESPACE_TEXT -> type(WHITESPACE);
-LEFT_PARENTHESIS : '(' -> mode(DEFAULT_MODE), pushMode(ARGUMENTS) ;
-TEXT_FALLBACK2A : -> type(TRANSITION), channel(HIDDEN), mode(DEFAULT_MODE) ;
+//TODO: Including spaces in LeftParenthesis is a bit of a hack
+WhitespaceA:  WHITESPACE_TEXT -> type(Whitespace);
+LeftParenthesis : '(' -> mode(DEFAULT_MODE), pushMode(ARGUMENTS) ;
+TextFallback2A : -> type(TRANSITION), channel(HIDDEN), mode(DEFAULT_MODE) ;
 
 
 //===================================
@@ -57,9 +57,9 @@ TEXT_FALLBACK2A : -> type(TRANSITION), channel(HIDDEN), mode(DEFAULT_MODE) ;
 // Because of this, we need match start & close comment tokens by pushing & poping the mode.
 mode BLOCK_COMMENT ;
 
-BLOCK_COMMENT_START3 : '#*' -> pushMode(BLOCK_COMMENT), type(BLOCK_COMMENT_START);
-BLOCK_COMMENT_END : '*#' -> popMode ;
-BLOCK_COMMENT_BODY :  (~('#' | '*') | '#' ~'*' | '*' ~'#')+ ;
+NestedBlockCommentStart : '#*' -> pushMode(BLOCK_COMMENT), type(BlockCommentStart);
+BlockCommentEnd : '*#' -> popMode ;
+BlockCommentBody :  (~('#' | '*') | '#' ~'*' | '*' ~'#')+ ;
 
 
 
@@ -68,11 +68,11 @@ BLOCK_COMMENT_BODY :  (~('#' | '*') | '#' ~'*' | '*' ~'#')+ ;
 //
 mode DOLLAR_SEEN ;
 
-IDENTIFIER : IDENTIFIER_TEXT -> mode(REFERENCE) ;
-EXCLAMATION : '!' ;
-LEFT_CURLEY : '{';
+Identifier : IDENTIFIER_TEXT -> mode(REFERENCE) ;
+Exclamation : '!' ;
+LeftCurley : '{';
 
-TEXT_FALLBACK4 : -> type(TRANSITION), channel(HIDDEN), mode(DEFAULT_MODE) ;
+TextFallback4 : -> type(TRANSITION), channel(HIDDEN), mode(DEFAULT_MODE) ;
 
 
 
@@ -81,12 +81,12 @@ TEXT_FALLBACK4 : -> type(TRANSITION), channel(HIDDEN), mode(DEFAULT_MODE) ;
 // text, or further member access.
 mode REFERENCE ;
 
-DOT : '.' ;
-IDENTIFIER5: IDENTIFIER_TEXT -> type(IDENTIFIER) , mode(REFERENCE_MEMBER_ACCESS) ;
-RIGHT_CURLEY : '}' ->  mode(DEFAULT_MODE);
+Dot : '.' ;
+Identifier5: IDENTIFIER_TEXT -> type(Identifier) , mode(REFERENCE_MEMBER_ACCESS) ;
+RightCurley : '}' ->  mode(DEFAULT_MODE);
 
-DOTDOT_TEXT5 : '..' -> type(TEXT), mode(DEFAULT_MODE) ;
-TEXT_FALLBACK5 : -> type(TRANSITION), channel(HIDDEN), mode(DEFAULT_MODE) ;
+DotDotText5 : '..' -> type(Text), mode(DEFAULT_MODE) ;
+TextFallback5 : -> type(TRANSITION), channel(HIDDEN), mode(DEFAULT_MODE) ;
 
 
 //===================================
@@ -95,8 +95,8 @@ TEXT_FALLBACK5 : -> type(TRANSITION), channel(HIDDEN), mode(DEFAULT_MODE) ;
 // Otherwise it is a property invocation and returns to the REFERENCE state.
 mode REFERENCE_MEMBER_ACCESS ;
 
-LEFT_PARENTHESIS6 : '(' -> type(LEFT_PARENTHESIS), mode(REFERENCE), pushMode(ARGUMENTS) ;
-TEXT_FALLBACK6 : -> type(TRANSITION), channel(HIDDEN), mode(REFERENCE) ;
+LeftParenthesis6 : '(' -> type(LeftParenthesis), mode(REFERENCE), pushMode(ARGUMENTS) ;
+TextFallback6 : -> type(TRANSITION), channel(HIDDEN), mode(REFERENCE) ;
 
 
 
@@ -105,36 +105,36 @@ TEXT_FALLBACK6 : -> type(TRANSITION), channel(HIDDEN), mode(REFERENCE) ;
 // or a directive #directive(ARGUMENTS)
 mode ARGUMENTS ;
 
-WHITESPACE7 : WHITESPACE_TEXT -> type(WHITESPACE), channel(HIDDEN);
-COMMA : ',' ;
-LEFT_PARENTHESIS7 : '(' -> type(LEFT_PARENTHESIS), pushMode(ARGUMENTS);
-RIGHT_PARENTHESIS : ')' -> popMode ;
-TRUE : 'true' ;
-FALSE : 'false' ;
-NUMBER : NUMERIC_CHAR+ ;
-DOT7 : '.' -> type(DOT) ;
-STRING : '\'' ~('\'' | '\r' | '\n' )* '\'' ;
-INTERPOLATED_STRING : '"' ~('"' | '\r' | '\n' )* '"' ;
-DOLLAR7 : '$' -> type(DOLLAR) ;
-EXCLAMATION7 : '!' -> type(EXCLAMATION) ;
-LEFT_CURLEY7 : '{' -> type(LEFT_CURLEY);
-RIGHT_CURLEY7 : '}' -> type(RIGHT_CURLEY);
-LEFT_SQUARE : '[' ;
-RIGHT_SQUARE : ']' ;
-DOTDOT : '..' ;
-ASSIGN : '=' ;
-MULTIPLY : '*' ;
-DIVIDE : '/' ;
-MODULO : '%' ;
-PLUS : '+' ;
-MINUS : '-' ;
-LESSTHAN : '<' | 'lt' ;
-GREATERTHAN : '>' | 'gt' ;
-LESSTHANOREQUAL : '<=' | 'le' ;
-GREATERTHANOREQUAL : '>=' | 'ge' ;
-EQUAL : '==' | 'eq' ;
-NOTEQUAL : '!=' | 'ne' ;
-AND : '&&' | 'and' ;
-OR : '||' | 'or' ;
-IDENTIFIER7 : IDENTIFIER_TEXT -> type(IDENTIFIER) ;
-UNKNOWN_CHAR : . ;
+Whitespace7 : WHITESPACE_TEXT -> type(Whitespace), channel(HIDDEN);
+Comma : ',' ;
+LeftParenthesis7 : '(' -> type(LeftParenthesis), pushMode(ARGUMENTS);
+RightParenthesis : ')' -> popMode ;
+True : 'true' ;
+False : 'false' ;
+Number : NUMERIC_CHAR+ ;
+Dot : '.' -> type(Dot) ;
+String : '\'' ~('\'' | '\r' | '\n' )* '\'' ;
+InterpolatedString : '"' ~('"' | '\r' | '\n' )* '"' ;
+Dollar7 : '$' -> type(Dollar) ;
+Exclamation7 : '!' -> type(Exclamation) ;
+LeftCurley7 : '{' -> type(LeftCurley);
+RightCurley7 : '}' -> type(RightCurley);
+LeftSquare : '[' ;
+RightSquare : ']' ;
+DotDot : '..' ;
+Assign : '=' ;
+Multiply : '*' ;
+Divide : '/' ;
+Modulo : '%' ;
+Plus : '+' ;
+Minus : '-' ;
+LessThan : '<' | 'lt' ;
+GreaterThan : '>' | 'gt' ;
+LessThanOrEqual : '<=' | 'le' ;
+GreaterThanOrEqual : '>=' | 'ge' ;
+Equal : '==' | 'eq' ;
+NotEqual : '!=' | 'ne' ;
+And : '&&' | 'and' ;
+Or : '||' | 'or' ;
+Identifier7 : IDENTIFIER_TEXT -> type(Identifier) ;
+UnknownChar : . ;

--- a/IronVelocity/Parser/VelocityParser.g4
+++ b/IronVelocity/Parser/VelocityParser.g4
@@ -10,7 +10,7 @@ template: block
 		| (end {NotifyErrorListeners("Unexpected #end"); } template)
 	) ;
 
-block: (text | reference | comment | set_directive | if_block | custom_directive )* ;
+block: (text | reference | comment | setDirective | ifBlock | customDirective )* ;
 
 //"DOLLAR  (EXCLAMATION | LEFT_CURLEY)*"" accounts for scenarios where the DOLLAR_SEEN
 // lexical state was entered, but did not move into the REFERENCE state
@@ -19,67 +19,67 @@ block: (text | reference | comment | set_directive | if_block | custom_directive
 text : (TEXT | HASH | DOLLAR (EXCLAMATION | LEFT_CURLEY)* | RIGHT_CURLEY | DOT | WHITESPACE | NEWLINE | ESCAPED_DOLLAR | ESCAPED_HASH | LONE_ESCAPE )+ ;
 
 
-comment : HASH COMMENT (NEWLINE | EOF) | HASH block_comment;
-block_comment : BLOCK_COMMENT_START (BLOCK_COMMENT_BODY | block_comment)*  BLOCK_COMMENT_END ;
+comment : HASH COMMENT (NEWLINE | EOF) | HASH blockComment;
+blockComment : BLOCK_COMMENT_START (BLOCK_COMMENT_BODY | blockComment)*  BLOCK_COMMENT_END ;
 
-reference : DOLLAR EXCLAMATION? reference_body
-	| DOLLAR EXCLAMATION? LEFT_CURLEY reference_body RIGHT_CURLEY;
+reference : DOLLAR EXCLAMATION? referenceBody
+	| DOLLAR EXCLAMATION? LEFT_CURLEY referenceBody RIGHT_CURLEY;
 
-reference_body : variable (DOT ( method_invocation | property_invocation))* ;
+referenceBody : variable (DOT ( methodInvocation | propertyInvocation))* ;
 
 variable : IDENTIFIER;
-property_invocation: IDENTIFIER ;
-method_invocation: IDENTIFIER LEFT_PARENTHESIS argument_list RIGHT_PARENTHESIS;
+propertyInvocation: IDENTIFIER ;
+methodInvocation: IDENTIFIER LEFT_PARENTHESIS argument_list RIGHT_PARENTHESIS;
 
 argument_list : (expression (COMMA expression)*)? ;
 
-directive_arguments: (WHITESPACE? LEFT_PARENTHESIS directive_argument* RIGHT_PARENTHESIS)? ;
-directive_argument : expression | directive_word;
-directive_word : IDENTIFIER;
-primary_expression : reference 
+directiveArguments: (WHITESPACE? LEFT_PARENTHESIS directiveArgument* RIGHT_PARENTHESIS)? ;
+directiveArgument : expression | directiveWord;
+directiveWord : IDENTIFIER;
+primaryExpression : reference 
 	| boolean
 	| float
 	| integer
 	| string
-	| interpolated_string
+	| interpolatedString
 	| list
 	| range 
-	| parenthesised_expression
+	| parenthesisedExpression
 	;
 
 boolean : TRUE | FALSE ;
 integer : MINUS? NUMBER ;
 float: MINUS? NUMBER DOT NUMBER ;
 string : STRING ;
-interpolated_string : INTERPOLATED_STRING ;
+interpolatedString : INTERPOLATED_STRING ;
 
 list : LEFT_SQUARE argument_list RIGHT_SQUARE ;
 range : LEFT_SQUARE expression  DOTDOT expression RIGHT_SQUARE ;
-parenthesised_expression : LEFT_PARENTHESIS expression RIGHT_PARENTHESIS;
+parenthesisedExpression : LEFT_PARENTHESIS expression RIGHT_PARENTHESIS;
 
-set_directive: HASH SET WHITESPACE? LEFT_PARENTHESIS assignment RIGHT_PARENTHESIS (WHITESPACE? NEWLINE)?;
-if_block : HASH IF WHITESPACE? LEFT_PARENTHESIS expression RIGHT_PARENTHESIS (WHITESPACE? NEWLINE)? block if_elseif_block* if_else_block?end ;
-if_elseif_block : HASH ELSEIF WHITESPACE? LEFT_PARENTHESIS expression RIGHT_PARENTHESIS (WHITESPACE? NEWLINE)? block ;
-if_else_block : HASH ELSE (WHITESPACE? NEWLINE)? block ;
+setDirective: HASH SET WHITESPACE? LEFT_PARENTHESIS assignment RIGHT_PARENTHESIS (WHITESPACE? NEWLINE)?;
+ifBlock : HASH IF WHITESPACE? LEFT_PARENTHESIS expression RIGHT_PARENTHESIS (WHITESPACE? NEWLINE)? block ifElseifBlock* ifElseBlock?end ;
+ifElseifBlock : HASH ELSEIF WHITESPACE? LEFT_PARENTHESIS expression RIGHT_PARENTHESIS (WHITESPACE? NEWLINE)? block ;
+ifElseBlock : HASH ELSE (WHITESPACE? NEWLINE)? block ;
 end: HASH END (WHITESPACE? NEWLINE)? ;
 
-custom_directive :
-	{ !IsBlockDirective()}?  HASH DIRECTIVE_NAME directive_arguments (WHITESPACE? NEWLINE)?
-	 |  {IsBlockDirective()}? HASH DIRECTIVE_NAME directive_arguments (WHITESPACE? NEWLINE)? block end ;
+customDirective :
+	{ !IsBlockDirective()}?  HASH DIRECTIVE_NAME directiveArguments (WHITESPACE? NEWLINE)?
+	 |  {IsBlockDirective()}? HASH DIRECTIVE_NAME directiveArguments (WHITESPACE? NEWLINE)? block end ;
 
 assignment: reference ASSIGN expression ;
 
-unary_expression : primary_expression
-	| EXCLAMATION unary_expression ;
-multiplicative_expression : unary_expression
-	| multiplicative_expression (MULTIPLY | DIVIDE | MODULO) unary_expression;
-additive_expression : multiplicative_expression
-	| additive_expression (PLUS | MINUS) multiplicative_expression;
-relational_expression : additive_expression
-	| relational_expression (LESSTHAN | GREATERTHAN | LESSTHANOREQUAL | GREATERTHANOREQUAL) additive_expression;
-equality_expression : relational_expression
-	| equality_expression (EQUAL | NOTEQUAL) relational_expression ;
-and_expression : equality_expression
-	| and_expression AND equality_expression ;
-expression : and_expression
-	| expression OR and_expression ;
+unaryExpression : primaryExpression
+	| EXCLAMATION unaryExpression ;
+multiplicativeExpression : unaryExpression
+	| multiplicativeExpression (MULTIPLY | DIVIDE | MODULO) unaryExpression;
+additiveExpression : multiplicativeExpression
+	| additiveExpression (PLUS | MINUS) multiplicativeExpression;
+relationalExpression : additiveExpression
+	| relationalExpression (LESSTHAN | GREATERTHAN | LESSTHANOREQUAL | GREATERTHANOREQUAL) additiveExpression;
+equalityExpression : relationalExpression
+	| equalityExpression (EQUAL | NOTEQUAL) relationalExpression ;
+andExpression : equalityExpression
+	| andExpression AND equalityExpression ;
+expression : andExpression
+	| expression OR andExpression ;

--- a/IronVelocity/Parser/VelocityParser.g4
+++ b/IronVelocity/Parser/VelocityParser.g4
@@ -58,7 +58,7 @@ range : LeftSquare expression  DotDot expression RightSquare ;
 parenthesisedExpression : LeftParenthesis expression RightParenthesis;
 
 setDirective: Hash Set Whitespace? LeftParenthesis assignment RightParenthesis (Whitespace? Newline)?;
-ifBlock : Hash If Whitespace? LeftParenthesis expression RightParenthesis (Whitespace? Newline)? block ifElseifBlock* ifElseBlock?end ;
+ifBlock : Hash If Whitespace? LeftParenthesis expression RightParenthesis (Whitespace? Newline)? block ifElseifBlock* ifElseBlock? end ;
 ifElseifBlock : Hash ElseIf Whitespace? LeftParenthesis expression RightParenthesis (Whitespace? Newline)? block ;
 ifElseBlock : Hash Else (Whitespace? Newline)? block ;
 end: Hash End (Whitespace? Newline)? ;

--- a/IronVelocity/Parser/VelocityParser.g4
+++ b/IronVelocity/Parser/VelocityParser.g4
@@ -12,30 +12,30 @@ template: block
 
 block: (text | reference | comment | setDirective | ifBlock | customDirective )* ;
 
-//"DOLLAR  (EXCLAMATION | LEFT_CURLEY)*"" accounts for scenarios where the DOLLAR_SEEN
+//"Dollar  (Exclamation | LeftCurley)*"" accounts for scenarios where the DOLLAR_SEEN
 // lexical state was entered, but did not move into the REFERENCE state
 // RIGHT_CURLEY required to cope with ${formal}}
 // DOT required to cope with "$name."
-text : (TEXT | HASH | DOLLAR (EXCLAMATION | LEFT_CURLEY)* | RIGHT_CURLEY | DOT | WHITESPACE | NEWLINE | ESCAPED_DOLLAR | ESCAPED_HASH | LONE_ESCAPE )+ ;
+text : (Text | Hash | Dollar (Exclamation | LeftCurley)* | RightCurley | Dot | Whitespace | Newline | EscapedDollar | EscapedHash | LoneEscape )+ ;
 
 
-comment : HASH COMMENT (NEWLINE | EOF) | HASH blockComment;
-blockComment : BLOCK_COMMENT_START (BLOCK_COMMENT_BODY | blockComment)*  BLOCK_COMMENT_END ;
+comment : Hash COMMENT (Newline | EOF) | Hash blockComment;
+blockComment : BlockCommentStart (BlockCommentBody | blockComment)*  BlockCommentEnd ;
 
-reference : DOLLAR EXCLAMATION? referenceBody
-	| DOLLAR EXCLAMATION? LEFT_CURLEY referenceBody RIGHT_CURLEY;
+reference : Dollar Exclamation? referenceBody
+	| Dollar Exclamation? LeftCurley referenceBody RightCurley;
 
-referenceBody : variable (DOT ( methodInvocation | propertyInvocation))* ;
+referenceBody : variable (Dot ( methodInvocation | propertyInvocation))* ;
 
-variable : IDENTIFIER;
-propertyInvocation: IDENTIFIER ;
-methodInvocation: IDENTIFIER LEFT_PARENTHESIS argument_list RIGHT_PARENTHESIS;
+variable : Identifier;
+propertyInvocation: Identifier ;
+methodInvocation: Identifier LeftParenthesis argument_list RightParenthesis;
 
-argument_list : (expression (COMMA expression)*)? ;
+argument_list : (expression (Comma expression)*)? ;
 
-directiveArguments: (WHITESPACE? LEFT_PARENTHESIS directiveArgument* RIGHT_PARENTHESIS)? ;
+directiveArguments: (Whitespace? LeftParenthesis directiveArgument* RightParenthesis)? ;
 directiveArgument : expression | directiveWord;
-directiveWord : IDENTIFIER;
+directiveWord : Identifier;
 primaryExpression : reference 
 	| boolean
 	| float
@@ -47,39 +47,39 @@ primaryExpression : reference
 	| parenthesisedExpression
 	;
 
-boolean : TRUE | FALSE ;
-integer : MINUS? NUMBER ;
-float: MINUS? NUMBER DOT NUMBER ;
-string : STRING ;
-interpolatedString : INTERPOLATED_STRING ;
+boolean : True | False ;
+integer : Minus? Number ;
+float: Minus? Number Dot Number ;
+string : String ;
+interpolatedString : InterpolatedString ;
 
-list : LEFT_SQUARE argument_list RIGHT_SQUARE ;
-range : LEFT_SQUARE expression  DOTDOT expression RIGHT_SQUARE ;
-parenthesisedExpression : LEFT_PARENTHESIS expression RIGHT_PARENTHESIS;
+list : LeftSquare argument_list RightSquare ;
+range : LeftSquare expression  DotDot expression RightSquare ;
+parenthesisedExpression : LeftParenthesis expression RightParenthesis;
 
-setDirective: HASH SET WHITESPACE? LEFT_PARENTHESIS assignment RIGHT_PARENTHESIS (WHITESPACE? NEWLINE)?;
-ifBlock : HASH IF WHITESPACE? LEFT_PARENTHESIS expression RIGHT_PARENTHESIS (WHITESPACE? NEWLINE)? block ifElseifBlock* ifElseBlock?end ;
-ifElseifBlock : HASH ELSEIF WHITESPACE? LEFT_PARENTHESIS expression RIGHT_PARENTHESIS (WHITESPACE? NEWLINE)? block ;
-ifElseBlock : HASH ELSE (WHITESPACE? NEWLINE)? block ;
-end: HASH END (WHITESPACE? NEWLINE)? ;
+setDirective: Hash Set Whitespace? LeftParenthesis assignment RightParenthesis (Whitespace? Newline)?;
+ifBlock : Hash If Whitespace? LeftParenthesis expression RightParenthesis (Whitespace? Newline)? block ifElseifBlock* ifElseBlock?end ;
+ifElseifBlock : Hash ElseIf Whitespace? LeftParenthesis expression RightParenthesis (Whitespace? Newline)? block ;
+ifElseBlock : Hash Else (Whitespace? Newline)? block ;
+end: Hash End (Whitespace? Newline)? ;
 
 customDirective :
-	{ !IsBlockDirective()}?  HASH DIRECTIVE_NAME directiveArguments (WHITESPACE? NEWLINE)?
-	 |  {IsBlockDirective()}? HASH DIRECTIVE_NAME directiveArguments (WHITESPACE? NEWLINE)? block end ;
+	{ !IsBlockDirective()}?  Hash DirectiveName directiveArguments (Whitespace? Newline)?
+	 |  {IsBlockDirective()}? Hash DirectiveName directiveArguments (Whitespace? Newline)? block end ;
 
-assignment: reference ASSIGN expression ;
+assignment: reference Assign expression ;
 
 unaryExpression : primaryExpression
-	| EXCLAMATION unaryExpression ;
+	| Exclamation unaryExpression ;
 multiplicativeExpression : unaryExpression
-	| multiplicativeExpression (MULTIPLY | DIVIDE | MODULO) unaryExpression;
+	| multiplicativeExpression (Multiply | Divide | Modulo) unaryExpression;
 additiveExpression : multiplicativeExpression
-	| additiveExpression (PLUS | MINUS) multiplicativeExpression;
+	| additiveExpression (Plus | Minus) multiplicativeExpression;
 relationalExpression : additiveExpression
-	| relationalExpression (LESSTHAN | GREATERTHAN | LESSTHANOREQUAL | GREATERTHANOREQUAL) additiveExpression;
+	| relationalExpression (LessThan | GreaterThan | LessThanOrEqual | GreaterThanOrEqual) additiveExpression;
 equalityExpression : relationalExpression
-	| equalityExpression (EQUAL | NOTEQUAL) relationalExpression ;
+	| equalityExpression (Equal | NotEqual) relationalExpression ;
 andExpression : equalityExpression
-	| andExpression AND equalityExpression ;
+	| andExpression And equalityExpression ;
 expression : andExpression
-	| expression OR andExpression ;
+	| expression Or andExpression ;


### PR DESCRIPTION
Updated the style used in the Antlr4 grammar files.  Tokens are now ProperCase, and parser rules are camelCase.