### PR TITLE
Reduce Whitespace in rendered output

### DIFF
--- a/IronVelocity.Tests/IronVelocity.Tests.csproj
+++ b/IronVelocity.Tests/IronVelocity.Tests.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Parser\Combination\TextCombinations.cs" />
     <Compile Include="Parser\DictionaryExpressionTests.cs" />
     <Compile Include="Parser\LiteralTests.cs" />
+    <Compile Include="Parser\WhitespaceTests.cs" />
     <Compile Include="TemplateExecution\BinderReuse\BinderReuseTestBase.cs" />
     <Compile Include="TemplateExecution\BinderReuse\GetMemberReuseTests.cs" />
     <Compile Include="TemplateExecution\BinderReuse\InvokeMemberReuseTests.cs" />
@@ -174,6 +175,7 @@
     <Compile Include="TemplateExecution\TemplateExecutionBase.cs" />
     <Compile Include="TemplateExecution\OutputTests.cs" />
     <Compile Include="TemplateExecution\TemplateTests.cs" />
+    <Compile Include="TemplateExecution\WhitespaceReductionTests.cs" />
     <Compile Include="Utility.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/IronVelocity.Tests/Parser/ArgumentListTests.cs
+++ b/IronVelocity.Tests/Parser/ArgumentListTests.cs
@@ -17,7 +17,7 @@ namespace IronVelocity.Tests.Parser
         [TestCase(3, " 1 , 1 , 1 ")]
         public void ParseArgumentList(int argumentCount, string input)
         {
-            var result = Parse(input, x => x.argument_list(), VelocityLexer.ARGUMENTS);
+            var result = Parse(input, x => x.argument_list(), VelocityLexer.EXPRESSION);
 
             Assert.That(result, Is.Not.Null);
             Assert.That(result.GetFullText(), Is.EqualTo(input.Trim()));
@@ -33,7 +33,7 @@ namespace IronVelocity.Tests.Parser
         [TestCase(",1")]
         public void ParseInvalidArgumentList(string input)
         {
-            ParseShouldProduceError(input, x => x.argument_list(), VelocityLexer.ARGUMENTS);
+            ParseShouldProduceError(input, x => x.argument_list(), VelocityLexer.EXPRESSION);
         }
     }
 }

--- a/IronVelocity.Tests/Parser/BooleanLiteralTests.cs
+++ b/IronVelocity.Tests/Parser/BooleanLiteralTests.cs
@@ -9,7 +9,7 @@ namespace IronVelocity.Tests.Parser
         [TestCase("false")]
         public void ParseBooleanLiteral(string input)
         {
-            var result = Parse(input, x => x.expression(), VelocityLexer.ARGUMENTS);
+            var result = Parse(input, x => x.expression(), VelocityLexer.EXPRESSION);
 
             Assert.That(result, Is.InstanceOf<VelocityParser.BooleanLiteralContext>());
             Assert.That(result.GetText(), Is.EqualTo(input));

--- a/IronVelocity.Tests/Parser/Combination/TextCombinations.cs
+++ b/IronVelocity.Tests/Parser/Combination/TextCombinations.cs
@@ -11,7 +11,7 @@ namespace IronVelocity.Tests.Parser.Combination
         [TestCaseSource(nameof(TextCombinationTestCases))]
         public void TextCombinationTest(string input, Type expectedNodeType, string expectedText)
         {
-            var result = Parse(input, x => x.block());
+            var result = Parse(input, x => x.text());
 
             Assert.That(result.ChildCount, Is.EqualTo(1));
 
@@ -37,8 +37,8 @@ namespace IronVelocity.Tests.Parser.Combination
                                 continue;
 
                             var input = left + right;
-                            yield return new TestCaseData(input, typeof(VelocityParser.TextContext), input)
-                                .SetName($"zCombination Test - {leftType}, {rightType} - {input}");
+                            yield return new TestCaseData(input, typeof(VelocityParser.RawTextContext), input)
+                                .SetName($"zText Combination Test - {input}");
                         }
                     }
                 }

--- a/IronVelocity.Tests/Parser/CommentTests.cs
+++ b/IronVelocity.Tests/Parser/CommentTests.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 namespace IronVelocity.Tests.Parser
 {
     [TestFixture(VelocityLexer.DefaultMode)]
-    [TestFixture(VelocityLexer.DOLLAR_SEEN)]
+    [TestFixture(VelocityLexer.POSSIBLE_REFERENCE)]
     [TestFixture(VelocityLexer.REFERENCE)]
     [TestFixture(VelocityLexer.REFERENCE_MEMBER_ACCESS)]
 

--- a/IronVelocity.Tests/Parser/DictionaryExpressionTests.cs
+++ b/IronVelocity.Tests/Parser/DictionaryExpressionTests.cs
@@ -17,7 +17,7 @@ namespace IronVelocity.Tests.Parser
         [TestCase("{ key : $value, key2 : $value2, foo : $bar, baz : $bizz}", 4)]
         public void ShouldParseDictionaryExpression(string input, int itemCount)
         {
-            var result = (VelocityParser.DictionaryExpressionContext)Parse(input, x => x.expression(), VelocityLexer.ARGUMENTS);
+            var result = (VelocityParser.DictionaryExpressionContext)Parse(input, x => x.expression(), VelocityLexer.EXPRESSION);
 
             Assert.That(result, Is.Not.Null);
             Assert.That(result.dictionaryEntry(), Has.Length.EqualTo(itemCount));
@@ -29,7 +29,7 @@ namespace IronVelocity.Tests.Parser
         [TestCase("\"interpolatedString\" : true", "\"interpolatedString\"", "true")]
         public void ShouldParseDictionaryEntry(string input, string key, string value)
         {
-            var result = Parse(input, x => x.dictionaryEntry(), VelocityLexer.ARGUMENTS);
+            var result = Parse(input, x => x.dictionaryEntry(), VelocityLexer.EXPRESSION);
 
             Assert.That(result, Is.Not.Null);
             Assert.That(result.dictionaryKey().GetText(), Is.EqualTo(key));

--- a/IronVelocity.Tests/Parser/DirectiveArgumentListTests.cs
+++ b/IronVelocity.Tests/Parser/DirectiveArgumentListTests.cs
@@ -20,7 +20,7 @@ namespace IronVelocity.Tests.Parser
         public void ParseDirectiveArgumentList(int argumentCount, string input)
         {
             input = $"({input})";
-            var result = Parse(input, x => x.directiveArguments(), VelocityLexer.ARGUMENTS);
+            var result = Parse(input, x => x.directiveArguments(), VelocityLexer.EXPRESSION);
 
             Assert.That(result, Is.Not.Null);
             Assert.That(result.GetFullText(), Is.EqualTo(input.Trim()));
@@ -32,7 +32,7 @@ namespace IronVelocity.Tests.Parser
         [TestCase("1,1")]
         public void ParseInvalidDirectiveArgumentList(string input)
         {
-            ParseShouldProduceError(input, x => x.directiveArguments(), VelocityLexer.ARGUMENTS);
+            ParseShouldProduceError(input, x => x.directiveArguments(), VelocityLexer.EXPRESSION);
         }
     }
 }

--- a/IronVelocity.Tests/Parser/FloatLiteralTests.cs
+++ b/IronVelocity.Tests/Parser/FloatLiteralTests.cs
@@ -14,7 +14,7 @@ namespace IronVelocity.Tests.Parser
         //TODO: Looks like velocity 1.7 allows specifying floats int he form 1.4E12
         public void ParseFloatLiteral(string input)
         {
-            var result = Parse(input, x => x.expression(), VelocityLexer.ARGUMENTS);
+            var result = Parse(input, x => x.expression(), VelocityLexer.EXPRESSION);
 
             Assert.That(result, Is.InstanceOf<VelocityParser.FloatingPointLiteralContext>());
             Assert.That(result.GetText(), Is.EqualTo(input));

--- a/IronVelocity.Tests/Parser/IntegerLiteralTests.cs
+++ b/IronVelocity.Tests/Parser/IntegerLiteralTests.cs
@@ -13,7 +13,7 @@ namespace IronVelocity.Tests.Parser
         [TestCase("-8765432109")]
         public void ParseIntegerLiteral(string input)
         {
-            var result = Parse(input, x => x.expression(), VelocityLexer.ARGUMENTS);
+            var result = Parse(input, x => x.expression(), VelocityLexer.EXPRESSION);
 
             Assert.That(result, Is.InstanceOf<VelocityParser.IntegerLiteralContext>());
             Assert.That(result.GetText(), Is.EqualTo(input));

--- a/IronVelocity.Tests/Parser/InterpolatedStringTests.cs
+++ b/IronVelocity.Tests/Parser/InterpolatedStringTests.cs
@@ -10,7 +10,7 @@ namespace IronVelocity.Tests.Parser
         [TestCase("\"'\"")]
         public void ParseInterpolatedString(string input)
         {
-            var result = Parse(input, x => x.@string(), VelocityLexer.ARGUMENTS);
+            var result = Parse(input, x => x.@string(), VelocityLexer.EXPRESSION);
 
             Assert.That(result, Is.InstanceOf<VelocityParser.InterpolatedStringLiteralContext>());
             Assert.That(result.GetText(), Is.EqualTo(input));
@@ -21,7 +21,7 @@ namespace IronVelocity.Tests.Parser
         {
             var input = "\"Bob said \"\"Hello\"\" to his neighbour\"";
 
-            var result = Parse(input, x => x.@string(), VelocityLexer.ARGUMENTS);
+            var result = Parse(input, x => x.@string(), VelocityLexer.EXPRESSION);
             Assert.That(result, Is.InstanceOf<VelocityParser.InterpolatedStringLiteralContext>());
             Assert.That(result.GetText(), Is.EqualTo(input));
         }

--- a/IronVelocity.Tests/Parser/ListTests.cs
+++ b/IronVelocity.Tests/Parser/ListTests.cs
@@ -13,7 +13,7 @@ namespace IronVelocity.Tests.Parser
         [TestCase("[$a, 23, 'foo']", 3)]
         public void ParseList(string input, int argumentCount)
         {
-            var result = (VelocityParser.ListContext)Parse(input, x => x.expression(), VelocityLexer.ARGUMENTS);
+            var result = (VelocityParser.ListContext)Parse(input, x => x.expression(), VelocityLexer.EXPRESSION);
 
             Assert.That(result, Is.Not.Null);
             Assert.That(result.GetFullText(), Is.EqualTo(input));

--- a/IronVelocity.Tests/Parser/ParserTestBase.cs
+++ b/IronVelocity.Tests/Parser/ParserTestBase.cs
@@ -58,7 +58,7 @@ namespace IronVelocity.Tests.Parser
 
         protected void ParseBinaryExpressionTest(string input, string left, string right, int operatorTokenKind, Func<VelocityParser, ParserRuleContext> parseFunc)
         {
-            var parsed = Parse(input, parseFunc, VelocityLexer.ARGUMENTS);
+            var parsed = Parse(input, parseFunc, VelocityLexer.EXPRESSION);
             Assert.That(parsed, Is.Not.Null);
             Assert.That(parsed.GetFullText(), Is.EqualTo(input.Trim()));
             Assert.That(parsed.ChildCount, Is.EqualTo(3));
@@ -72,7 +72,7 @@ namespace IronVelocity.Tests.Parser
 
         protected void ParseTernaryExpressionWithEqualPrecedenceTest(string input, int leftOperatorKind, int rightOperatorKind, Func<VelocityParser, ParserRuleContext> parseFunc)
         {
-            var parsed = Parse(input, parseFunc, VelocityLexer.ARGUMENTS);
+            var parsed = Parse(input, parseFunc, VelocityLexer.EXPRESSION);
             Assert.That(parsed, Is.Not.Null);
 
             Assert.That(parsed.GetFullText(), Is.EqualTo(input));

--- a/IronVelocity.Tests/Parser/PrimaryExpressionTests.cs
+++ b/IronVelocity.Tests/Parser/PrimaryExpressionTests.cs
@@ -15,7 +15,7 @@ namespace IronVelocity.Tests.Parser
         [TestCase("[1..3]", typeof(VelocityParser.RangeContext))]
         public void ParsePrimaryExpression(string input, Type parsedNodeType)
         {
-            var result = Parse(input, x => x.expression(), VelocityLexer.ARGUMENTS);
+            var result = Parse(input, x => x.expression(), VelocityLexer.EXPRESSION);
 
             Assert.That(result, Is.InstanceOf(parsedNodeType));
             Assert.That(result.GetText(), Is.EqualTo(input));

--- a/IronVelocity.Tests/Parser/RangeTests.cs
+++ b/IronVelocity.Tests/Parser/RangeTests.cs
@@ -14,7 +14,7 @@ namespace IronVelocity.Tests.Parser
         [TestCase("[true..[]]", typeof(VelocityParser.BooleanLiteralContext), typeof(VelocityParser.ListContext))]
         public void ParseRangeExpression(string input, Type leftArgType, Type rightArgType)
         {
-            var result = (VelocityParser.RangeContext)Parse(input, x => x.expression(), VelocityLexer.ARGUMENTS);
+            var result = (VelocityParser.RangeContext)Parse(input, x => x.expression(), VelocityLexer.EXPRESSION);
 
             Assert.That(result, Is.Not.Null);
             Assert.That(result.GetText(), Is.EqualTo(input));

--- a/IronVelocity.Tests/Parser/ReferenceTests.cs
+++ b/IronVelocity.Tests/Parser/ReferenceTests.cs
@@ -9,7 +9,7 @@ namespace IronVelocity.Tests.Parser
     [TestFixture(VelocityLexer.POSSIBLE_REFERENCE)]
     [TestFixture(VelocityLexer.REFERENCE)]
     [TestFixture(VelocityLexer.REFERENCE_MEMBER_ACCESS)]
-    [TestFixture(VelocityLexer.ARGUMENTS)]
+    [TestFixture(VelocityLexer.EXPRESSION)]
     public class ReferenceTests : ParserTestBase
     {
         private readonly int LexerInitialState;

--- a/IronVelocity.Tests/Parser/ReferenceTests.cs
+++ b/IronVelocity.Tests/Parser/ReferenceTests.cs
@@ -5,8 +5,8 @@ using System.Linq;
 namespace IronVelocity.Tests.Parser
 {
     [TestFixture(VelocityLexer.DefaultMode)]
-    [TestFixture(VelocityLexer.HASH_SEEN)]
-    [TestFixture(VelocityLexer.DOLLAR_SEEN)]
+    [TestFixture(VelocityLexer.POSSIBLE_CUSTOM_DIRECTIVE)]
+    [TestFixture(VelocityLexer.POSSIBLE_REFERENCE)]
     [TestFixture(VelocityLexer.REFERENCE)]
     [TestFixture(VelocityLexer.REFERENCE_MEMBER_ACCESS)]
     [TestFixture(VelocityLexer.ARGUMENTS)]

--- a/IronVelocity.Tests/Parser/StringTests.cs
+++ b/IronVelocity.Tests/Parser/StringTests.cs
@@ -10,7 +10,7 @@ namespace IronVelocity.Tests.Parser
         [TestCase("'\"'")]
         public void ParseStringLiteral(string input)
         {
-            var result = Parse(input, x => x.@string(), VelocityLexer.ARGUMENTS);
+            var result = Parse(input, x => x.@string(), VelocityLexer.EXPRESSION);
 
             Assert.That(result, Is.InstanceOf<VelocityParser.StringLiteralContext>());
             Assert.That(result.GetText(), Is.EqualTo(input));
@@ -21,7 +21,7 @@ namespace IronVelocity.Tests.Parser
         {
             var input = "'Jim''s Foo'";
 
-            var result = Parse(input, x => x.@string(), VelocityLexer.ARGUMENTS);
+            var result = Parse(input, x => x.@string(), VelocityLexer.EXPRESSION);
 
             Assert.That(result, Is.InstanceOf<VelocityParser.StringLiteralContext>());
             Assert.That(result.GetText(), Is.EqualTo(input));

--- a/IronVelocity.Tests/Parser/UnaryExpressionTests.cs
+++ b/IronVelocity.Tests/Parser/UnaryExpressionTests.cs
@@ -11,7 +11,7 @@ namespace IronVelocity.Tests.Parser
             var target= "$target";
             var input = @operator + target;
 
-            var parsed = Parse(input, x => x.expression(), VelocityLexer.ARGUMENTS);
+            var parsed = Parse(input, x => x.expression(), VelocityLexer.EXPRESSION);
             Assert.That(parsed, Is.Not.Null);
             Assert.That(parsed.GetText(), Is.EqualTo(input));
             Assert.That(parsed.ChildCount, Is.EqualTo(2));

--- a/IronVelocity.Tests/Parser/WhitespaceTests.cs
+++ b/IronVelocity.Tests/Parser/WhitespaceTests.cs
@@ -1,0 +1,19 @@
+﻿using NUnit.Framework;
+
+namespace IronVelocity.Tests.Parser
+{
+	public class WhitespaceTests : ParserTestBase
+	{
+		[TestCase(" ")]
+		[TestCase("\t")]
+		[TestCase("\t \t \t")]
+		[TestCase("\n")]
+		[TestCase("\r\n")]
+		[TestCase("  \n \r\n \t")]
+		public void ParseWhitespace(string input)
+		{
+			var literal = Parse(input, x => x.whitespace());
+			Assert.That(literal.GetText(), Is.EqualTo(input));
+		}
+	}
+}

--- a/IronVelocity.Tests/TemplateExecution/TemplateExecutionBase.cs
+++ b/IronVelocity.Tests/TemplateExecution/TemplateExecutionBase.cs
@@ -71,7 +71,7 @@ namespace IronVelocity.Tests.TemplateExecution
         }
 
 
-        public ExecutionResult ExecuteTemplate(string input, object locals = null, object globals = null, IReadOnlyList<CustomDirectiveBuilder> customDirectives = null, string fileName = null)
+        public ExecutionResult ExecuteTemplate(string input, object locals = null, object globals = null, IReadOnlyList<CustomDirectiveBuilder> customDirectives = null, string fileName = null, bool reduceWhitespace = false)
         {
             var localsDictionary = ConvertToDictionary(locals);
             var globalsDictionary = ConvertToDictionary(globals)?.ToImmutableDictionary();
@@ -81,7 +81,7 @@ namespace IronVelocity.Tests.TemplateExecution
 
             fileName = fileName ?? Utility.GetName();
 
-            var template = CompileTemplate(input, fileName, globalsDictionary, customDirectives?.ToImmutableList());
+            var template = CompileTemplate(input, fileName, globalsDictionary, customDirectives?.ToImmutableList(), reduceWhitespace);
 
             var context = new VelocityContext(localsDictionary);
 
@@ -98,7 +98,7 @@ namespace IronVelocity.Tests.TemplateExecution
         protected virtual IBinderFactory CreateBinderFactory()
             => new ReusableBinderFactory(new BinderFactory());
 
-        private VelocityTemplateMethod CompileTemplate(string input, string fileName, IImmutableDictionary<string, object> globals, IImmutableList<CustomDirectiveBuilder> customDirectives)
+        private VelocityTemplateMethod CompileTemplate(string input, string fileName, IImmutableDictionary<string, object> globals, IImmutableList<CustomDirectiveBuilder> customDirectives, bool reduceWhitespace)
         {
             //This is for debugging - change it with the Immediate window if you need to dump a test to disk for further investigation.
             bool saveDllAndExtractIlForTroubleshooting = false;
@@ -108,7 +108,7 @@ namespace IronVelocity.Tests.TemplateExecution
                 ? new VelocityExpressionFactory(binderFactory)
                 : new StaticTypedVelocityExpressionFactory(binderFactory, globals);
 
-            var parser = new AntlrVelocityParser(customDirectives, expressionFactory);
+            var parser = new AntlrVelocityParser(customDirectives, expressionFactory, reduceWhitespace);
 
             VelocityDiskCompiler diskCompiler = null;
 

--- a/IronVelocity.Tests/TemplateExecution/WhitespaceReductionTests.cs
+++ b/IronVelocity.Tests/TemplateExecution/WhitespaceReductionTests.cs
@@ -1,0 +1,41 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace IronVelocity.Tests.TemplateExecution
+{
+	[TestFixture(StaticTypingMode.AsProvided)]
+	[TestFixture(StaticTypingMode.PromoteContextToGlobals)]
+	public class WhitespaceReductionTests : TemplateExeuctionBase
+	{
+		public WhitespaceReductionTests(StaticTypingMode mode) : base(mode)
+		{
+		}
+
+		[TestCase(" ")]
+		[TestCase("\t")]
+		[TestCase("          ")]
+		[TestCase("\t\t\t\t")]
+		[TestCase("  \t  \t   ")]
+		public void WhenRenderingHorizontalWhitespace_ASingleSpaceIsEmitted(string input)
+		{
+			var result = ExecuteTemplate(input, reduceWhitespace: true);
+			Assert.That(result.Output, Is.EqualTo(" "));
+		}
+
+		[TestCase("\n")]
+		[TestCase("\r\n")]
+		[TestCase("\r\n\r\n\n\n")]
+		[TestCase(" \r\n \t \n")]
+		public void WhenRenderingVerticalWhitespace_ASingeNewlineIsEmitted(string input)
+		{
+			var result = ExecuteTemplate(input, reduceWhitespace: true);
+			Assert.That(result.Output, Is.EqualTo("\n"));
+
+		}
+
+	}
+}

--- a/IronVelocity/Parser/AntlrToExpressionTreeCompiler.cs
+++ b/IronVelocity/Parser/AntlrToExpressionTreeCompiler.cs
@@ -515,5 +515,10 @@ namespace IronVelocity.Parser
         {
             throw new NotImplementedException();
         }
+
+        public Expression VisitEndOfLineWhitespace([NotNull] VelocityParser.EndOfLineWhitespaceContext context)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/IronVelocity/Parser/AntlrToExpressionTreeCompiler.cs
+++ b/IronVelocity/Parser/AntlrToExpressionTreeCompiler.cs
@@ -55,9 +55,6 @@ namespace IronVelocity.Parser
 
                 switch (token.Type)
                 {
-                    case VelocityLexer.Whitespace:
-                    case VelocityLexer.Newline:
-                        goto default;
                     case VelocityLexer.EscapedDollar:
                         _textBuffer.Append('$');
                         break;

--- a/IronVelocity/Parser/AntlrVelocityParser.cs
+++ b/IronVelocity/Parser/AntlrVelocityParser.cs
@@ -22,15 +22,18 @@ namespace IronVelocity.Parser
         private readonly IImmutableList<CustomDirectiveBuilder> _customDirectives;
         private readonly VelocityExpressionFactory _expressionFactory;
 
+		public bool ReduceWhitespace { get; }
+
         public AntlrVelocityParser(VelocityExpressionFactory expressionFactory)
             : this(null, expressionFactory)
         {
         }
 
-        public AntlrVelocityParser(IImmutableList<CustomDirectiveBuilder> customDirectives, VelocityExpressionFactory expressionFactory)
+        public AntlrVelocityParser(IImmutableList<CustomDirectiveBuilder> customDirectives, VelocityExpressionFactory expressionFactory, bool reduceWhitespace = false)
         {
             _customDirectives = customDirectives ?? DefaultDirectives;
             _expressionFactory = expressionFactory;
+			ReduceWhitespace = reduceWhitespace;
         }
 
         public Expression<VelocityTemplateMethod> Parse(string input, string name)
@@ -118,7 +121,7 @@ namespace IronVelocity.Parser
 
         internal Expression<VelocityTemplateMethod> CompileToTemplateMethod(RuleContext parsed, string name)
         {
-            var visitor = new AntlrToExpressionTreeCompiler(this, _customDirectives, _expressionFactory);
+            var visitor = new AntlrToExpressionTreeCompiler(this, _customDirectives, _expressionFactory, ReduceWhitespace);
 
             TemplateGenerationEventSource.Log.ConvertToExpressionTreeStart(name);
             var body = visitor.Visit(parsed);

--- a/IronVelocity/Parser/VelocityLexer.g4
+++ b/IronVelocity/Parser/VelocityLexer.g4
@@ -31,7 +31,7 @@ LiteralContent : '#[[' (~(']') | ']' ~(']'))* ']]' ;
 Dollar : '$' ->  mode(POSSIBLE_REFERENCE) ;
 Hash : '#' -> mode(POSSIBLE_CUSTOM_DIRECTIVE) ;
 
-Whitespace:  WHITESPACE_TEXT ;
+VerticalWhitespace:  WHITESPACE_TEXT ;
 Newline : '\r' | '\n' | '\r\n' ;
 EscapedDollar: '\\'+ '$' ;
 EscapedHash: '\\'+ '#' ;
@@ -50,9 +50,9 @@ TextFallback1 : -> type(TRANSITION), channel(HIDDEN), mode(DEFAULT_MODE) ;
 mode DIRECTIVE_ARGUMENTS ;
 
 RightCurley : '}' ;
-WhitespaceA:  WHITESPACE_TEXT -> type(Whitespace);
+VerticalWhitespaceA:  WHITESPACE_TEXT -> type(VerticalWhitespace);
 LeftParenthesis : '(' -> mode(DEFAULT_MODE), pushMode(EXPRESSION) ;
-TextFallback2 : -> type(TRANSITION), channel(HIDDEN), mode(DEFAULT_MODE) ;
+TextFallback2A : -> type(TRANSITION), channel(HIDDEN), mode(DEFAULT_MODE) ;
 
 
 //===================================
@@ -144,7 +144,7 @@ Or : '||' | 'or' ;
 Dollar7 : '$' -> type(Dollar) ;
 Comma : ',' ;
 Colon : ':' ;
-Whitespace7 : WHITESPACE_TEXT -> type(Whitespace), channel(HIDDEN);
+VerticalWhitespace7 : WHITESPACE_TEXT -> type(VerticalWhitespace), channel(HIDDEN);
 Identifier7 : IDENTIFIER_TEXT -> type(Identifier) ;
 
 //Error Recovery

--- a/IronVelocity/Parser/VelocityLexer.g4
+++ b/IronVelocity/Parser/VelocityLexer.g4
@@ -51,7 +51,7 @@ mode DIRECTIVE_ARGUMENTS ;
 
 RightCurley : '}' ;
 WhitespaceA:  WHITESPACE_TEXT -> type(Whitespace);
-LeftParenthesis : '(' -> mode(DEFAULT_MODE), pushMode(ARGUMENTS) ;
+LeftParenthesis : '(' -> mode(DEFAULT_MODE), pushMode(EXPRESSION) ;
 TextFallback2 : -> type(TRANSITION), channel(HIDDEN), mode(DEFAULT_MODE) ;
 
 
@@ -86,7 +86,7 @@ mode REFERENCE ;
 
 Dot : '.' ;
 Identifier5: IDENTIFIER_TEXT -> type(Identifier) , mode(REFERENCE_MEMBER_ACCESS) ;
-LeftSquare5 : '[' -> type(LeftSquare), pushMode(ARGUMENTS);
+LeftSquare5 : '[' -> type(LeftSquare), pushMode(EXPRESSION);
 RightCurley5 : '}' ->  type(RightCurley), mode(DEFAULT_MODE);
 
 DotDotText5 : '..' -> type(Text), mode(DEFAULT_MODE) ;
@@ -99,30 +99,33 @@ TextFallback5 : -> type(TRANSITION), channel(HIDDEN), mode(DEFAULT_MODE) ;
 // Otherwise it is a property invocation and returns to the REFERENCE state.
 mode REFERENCE_MEMBER_ACCESS ;
 
-LeftParenthesis6 : '(' -> type(LeftParenthesis), mode(REFERENCE), pushMode(ARGUMENTS) ;
-LeftSquare6 : '[' -> type(LeftSquare), pushMode(ARGUMENTS);
+LeftParenthesis6 : '(' -> type(LeftParenthesis), mode(REFERENCE), pushMode(EXPRESSION) ;
+LeftSquare6 : '[' -> type(LeftSquare), pushMode(EXPRESSION);
 TextFallback6 : -> type(TRANSITION), channel(HIDDEN), mode(REFERENCE) ;
 
 
 //===================================
 // Used when parsing arguments in either a method call "$foo.bar(ARGUMENTS)",
 // or a directive #directive(ARGUMENTS)
-mode ARGUMENTS ;
+mode EXPRESSION ;
 
-Whitespace7 : WHITESPACE_TEXT -> type(Whitespace), channel(HIDDEN);
-Comma : ',' ;
 True : 'true' ;
 False : 'false' ;
 Number : NUMERIC_CHAR+ ;
-Dot7 : '.' -> type(Dot) ;
 String : '\'' (~('\'' | '\r' | '\n' ) | '\'\'' )* '\'' ;
 InterpolatedString : '"' (~('"' | '\r' | '\n' ) | '""')* '"' ;
-Dollar7 : '$' -> type(Dollar) ;
-Exclamation7 : '!' -> type(Exclamation) ;
+
+LeftParenthesis8 : '(' -> type(LeftParenthesis), pushMode(EXPRESSION);
+RightParenthesis : ')' -> popMode ;
 LeftCurley7 : '{' -> type(LeftCurley);
 RightCurley7 : '}' -> type(RightCurley);
+LeftSquare : '['  -> pushMode(EXPRESSION);
+RightSquare : ']' -> popMode ;
+
+Dot7 : '.' -> type(Dot) ;
+Exclamation7 : '!' -> type(Exclamation) ;
+
 DotDot : '..' ;
-Colon : ':' ;
 Assign : '=' ;
 Multiply : '*' ;
 Divide : '/' ;
@@ -137,9 +140,12 @@ Equal : '==' | 'eq' ;
 NotEqual : '!=' | 'ne' ;
 And : '&&' | 'and' ;
 Or : '||' | 'or' ;
+
+Dollar7 : '$' -> type(Dollar) ;
+Comma : ',' ;
+Colon : ':' ;
+Whitespace7 : WHITESPACE_TEXT -> type(Whitespace), channel(HIDDEN);
 Identifier7 : IDENTIFIER_TEXT -> type(Identifier) ;
-LeftParenthesis8 : '(' -> type(LeftParenthesis), pushMode(ARGUMENTS);
-RightParenthesis : ')' -> popMode ;
-LeftSquare : '['  -> pushMode(ARGUMENTS);
-RightSquare : ']' -> popMode ;
+
+//Error Recovery
 UnknownChar : .;

--- a/IronVelocity/Parser/VelocityParser.g4
+++ b/IronVelocity/Parser/VelocityParser.g4
@@ -10,14 +10,17 @@ template: block
 		| (end {NotifyErrorListeners("Unexpected #end"); } template)
 	) ;
 
-block: (text | reference | comment | setDirective | ifBlock | customDirective | literal)* ;
+block: (text | reference | setDirective | ifBlock | customDirective | comment)* ;
+
+text: (rawText | literal | whitespace)+ ;
 
 //"Dollar  (Exclamation | LeftCurley)*"" accounts for scenarios where the DOLLAR_SEEN
 // lexical state was entered, but did not move into the REFERENCE state
 // RIGHT_CURLEY required to cope with ${formal}}
 // DOT required to cope with "$name."
-text : (Text | Hash | Dollar (Exclamation | LeftCurley)* | RightCurley | Dot | VerticalWhitespace | Newline | EscapedDollar | EscapedHash | LoneEscape )+ ;
+rawText : (Text | Hash | Dollar (Exclamation | LeftCurley)* | RightCurley | Dot | EscapedDollar | EscapedHash | LoneEscape )+ ;
 
+whitespace: (VerticalWhitespace | Newline)+ ;
 
 comment : COMMENT (Newline | EOF) | blockComment;
 blockComment : BlockCommentStart (BlockCommentBody | blockComment)*  BlockCommentEnd ;

--- a/IronVelocity/Parser/VelocityParser.g4
+++ b/IronVelocity/Parser/VelocityParser.g4
@@ -26,16 +26,18 @@ directiveArguments: (Whitespace? LeftParenthesis directiveArgument* RightParenth
 directiveArgument : expression | directiveWord;
 directiveWord : Identifier;
 
+endOfLineWhitespace : Whitespace? Newline ;
+
 literal : LiteralContent;
-setDirective: Set Whitespace? LeftParenthesis assignment RightParenthesis (Whitespace? Newline)?;
-ifBlock : If Whitespace? LeftParenthesis expression RightParenthesis (Whitespace? Newline)? block ifElseifBlock* ifElseBlock? end ;
-ifElseifBlock : ElseIf Whitespace? LeftParenthesis expression RightParenthesis (Whitespace? Newline)? block ;
-ifElseBlock : Else (Whitespace? Newline)? block ;
-end: End (Whitespace? Newline)? ;
+setDirective: Set Whitespace? LeftParenthesis assignment RightParenthesis endOfLineWhitespace?;
+ifBlock : If Whitespace? LeftParenthesis expression RightParenthesis endOfLineWhitespace? block ifElseifBlock* ifElseBlock? end ;
+ifElseifBlock : ElseIf Whitespace? LeftParenthesis expression RightParenthesis endOfLineWhitespace? block ;
+ifElseBlock : Else endOfLineWhitespace? block ;
+end: End endOfLineWhitespace? ;
 
 customDirective :
-	{ !IsBlockDirective()}?  Hash (DirectiveName | LeftCurley DirectiveName RightCurley) directiveArguments (Whitespace? Newline)?
-	 |  {IsBlockDirective()}? Hash (DirectiveName | LeftCurley DirectiveName RightCurley) directiveArguments (Whitespace? Newline)? block end ;
+	{ !IsBlockDirective()}?  Hash (DirectiveName | LeftCurley DirectiveName RightCurley) directiveArguments endOfLineWhitespace?
+	 |  {IsBlockDirective()}? Hash (DirectiveName | LeftCurley DirectiveName RightCurley) directiveArguments endOfLineWhitespace? block end ;
 
 
 reference : Dollar Exclamation? referenceBody

--- a/IronVelocity/Parser/VelocityParser.g4
+++ b/IronVelocity/Parser/VelocityParser.g4
@@ -16,24 +16,25 @@ block: (text | reference | comment | setDirective | ifBlock | customDirective | 
 // lexical state was entered, but did not move into the REFERENCE state
 // RIGHT_CURLEY required to cope with ${formal}}
 // DOT required to cope with "$name."
-text : (Text | Hash | Dollar (Exclamation | LeftCurley)* | RightCurley | Dot | Whitespace | Newline | EscapedDollar | EscapedHash | LoneEscape )+ ;
+text : (Text | Hash | Dollar (Exclamation | LeftCurley)* | RightCurley | Dot | VerticalWhitespace | Newline | EscapedDollar | EscapedHash | LoneEscape )+ ;
 
 
 comment : COMMENT (Newline | EOF) | blockComment;
 blockComment : BlockCommentStart (BlockCommentBody | blockComment)*  BlockCommentEnd ;
 
-directiveArguments: (Whitespace? LeftParenthesis directiveArgument* RightParenthesis)? ;
+directiveArguments: (VerticalWhitespace? LeftParenthesis directiveArgument* RightParenthesis)? ;
 directiveArgument : expression | directiveWord;
 directiveWord : Identifier;
 
-endOfLineWhitespace : Whitespace? Newline ;
+endOfLineWhitespace : VerticalWhitespace? Newline ;
 
 literal : LiteralContent;
-setDirective: Set Whitespace? LeftParenthesis assignment RightParenthesis endOfLineWhitespace?;
-ifBlock : If Whitespace? LeftParenthesis expression RightParenthesis endOfLineWhitespace? block ifElseifBlock* ifElseBlock? end ;
-ifElseifBlock : ElseIf Whitespace? LeftParenthesis expression RightParenthesis endOfLineWhitespace? block ;
+setDirective: Set VerticalWhitespace? LeftParenthesis assignment RightParenthesis endOfLineWhitespace?;
+ifBlock : If VerticalWhitespace? LeftParenthesis expression RightParenthesis endOfLineWhitespace? block ifElseifBlock* ifElseBlock? end ;
+ifElseifBlock : ElseIf VerticalWhitespace? LeftParenthesis expression RightParenthesis endOfLineWhitespace? block ;
 ifElseBlock : Else endOfLineWhitespace? block ;
 end: End endOfLineWhitespace? ;
+
 
 customDirective :
 	{ !IsBlockDirective()}?  Hash (DirectiveName | LeftCurley DirectiveName RightCurley) directiveArguments endOfLineWhitespace?

--- a/IronVelocity/Parser/VelocityParser.g4
+++ b/IronVelocity/Parser/VelocityParser.g4
@@ -19,19 +19,19 @@ block: (text | reference | comment | setDirective | ifBlock | customDirective | 
 text : (Text | Hash | Dollar (Exclamation | LeftCurley)* | RightCurley | Dot | Whitespace | Newline | EscapedDollar | EscapedHash | LoneEscape )+ ;
 
 
-comment : Hash COMMENT (Newline | EOF) | Hash blockComment;
+comment : COMMENT (Newline | EOF) | blockComment;
 blockComment : BlockCommentStart (BlockCommentBody | blockComment)*  BlockCommentEnd ;
 
 directiveArguments: (Whitespace? LeftParenthesis directiveArgument* RightParenthesis)? ;
 directiveArgument : expression | directiveWord;
 directiveWord : Identifier;
 
-literal : Hash LiteralContent;
-setDirective: Hash (Set | LeftCurley Set RightCurley) Whitespace? LeftParenthesis assignment RightParenthesis (Whitespace? Newline)?;
-ifBlock : Hash (If | LeftCurley If RightCurley) Whitespace? LeftParenthesis expression RightParenthesis (Whitespace? Newline)? block ifElseifBlock* ifElseBlock? end ;
-ifElseifBlock : Hash (ElseIf | LeftCurley ElseIf RightCurley) Whitespace? LeftParenthesis expression RightParenthesis (Whitespace? Newline)? block ;
-ifElseBlock : Hash (Else | LeftCurley Else RightCurley) (Whitespace? Newline)? block ;
-end: Hash (End | LeftCurley End RightCurley) (Whitespace? Newline)? ;
+literal : LiteralContent;
+setDirective: Set Whitespace? LeftParenthesis assignment RightParenthesis (Whitespace? Newline)?;
+ifBlock : If Whitespace? LeftParenthesis expression RightParenthesis (Whitespace? Newline)? block ifElseifBlock* ifElseBlock? end ;
+ifElseifBlock : ElseIf Whitespace? LeftParenthesis expression RightParenthesis (Whitespace? Newline)? block ;
+ifElseBlock : Else (Whitespace? Newline)? block ;
+end: End (Whitespace? Newline)? ;
 
 customDirective :
 	{ !IsBlockDirective()}?  Hash (DirectiveName | LeftCurley DirectiveName RightCurley) directiveArguments (Whitespace? Newline)?


### PR DESCRIPTION
By default, whitespace will be rendered as is.  When the `OptimiseWhitespace` options is specified when creating `AntlrVelocityParser`, whitespace rendering is changed as follows:

* A sequence of ` ` and `\t` are replaced by a single space.
* A sequence of newlines gets replaced by a single `\n`.
* A sequence of both vertical and horizontal whitespace also gets replaced by a single `\n`