### PR TITLE
Publish packages to feed

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -8,8 +8,8 @@ on:
 
 env:
   Configuration: Release
-  VersionPrefix: 0.0.$GITHUB_RUN_NUMBER
-  VersionSuffix: alpha+$GITHUB_SHA
+  VersionPrefix: 0.0.${{env.GITHUB_RUN_NUMBER}}
+  VersionSuffix: alpha+${{env.GITHUB_SHA}}
 
 jobs:
   build:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -30,7 +30,7 @@ jobs:
       run: dotnet test --no-build
 
     - name: Pack
-      run: dotnet pack --no-build --include-symbols
+      run: dotnet pack --no-build --include-symbols --output ${{ runner.temp }}\nuget
 
     - name: Publish
-      run: dotnet nuget push "*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --source https://nuget.pkg.github.com/${{ github.repository_owner }}
+      run: dotnet nuget push "${{ runner.temp }}\nuget\*" --api-key ${{ secrets.GITHUB_TOKEN }} --source https://nuget.pkg.github.com/${{ github.repository_owner }}

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -5,14 +5,13 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-
-env:
-  Configuration: Release
-  VersionPrefix: 0.0.${{env.GITHUB_RUN_NUMBER}}
-  VersionSuffix: alpha+${{env.GITHUB_SHA}}
-
 jobs:
   build:
+    env:
+      Configuration: Release
+      VersionPrefix: 0.0.${{ github.run_number }}
+      VersionSuffix: alpha+${{ github.sha }}
+    
     runs-on: windows-latest
 
     steps:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -8,8 +8,8 @@ on:
 
 env:
   Configuration: Release
-  VersionPrefix: 0.0.${{ github.run_number }}
-  VersionSuffix: alpha+${{ github.github.sha }}
+  VersionPrefix: 0.0.$GITHUB_RUN_NUMBER
+  VersionSuffix: alpha+$GITHUB_SHA
 
 jobs:
   build:
@@ -25,7 +25,7 @@ jobs:
       run: dotnet restore
       
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --no-restore
       
     - name: Test
       run: dotnet test --no-build

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -31,3 +31,9 @@ jobs:
 
     - name: Pack
       run: dotnet pack --no-build --include-symbols
+
+    - name: Publish
+      run: |
+        dotnet nuget push "*.nupkg" \
+          --api-key ${{ secrets.GITHUB_TOKEN }} \
+          --source https://nuget.pkg.github.com/${{ github.repository_owner }}

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -30,7 +30,7 @@ jobs:
       run: dotnet test --no-build
 
     - name: Pack
-      run: dotnet pack --no-build --include-symbols --output ${{ runner.temp }}\nuget
+      run: dotnet pack --no-build --output ${{ runner.temp }}\nuget
 
     - name: Publish
       run: dotnet nuget push "${{ runner.temp }}\nuget\*" --api-key ${{ secrets.GITHUB_TOKEN }} --source https://nuget.pkg.github.com/${{ github.repository_owner }}

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -33,7 +33,4 @@ jobs:
       run: dotnet pack --no-build --include-symbols
 
     - name: Publish
-      run: |
-        dotnet nuget push "*.nupkg" \
-          --api-key ${{ secrets.GITHUB_TOKEN }} \
-          --source https://nuget.pkg.github.com/${{ github.repository_owner }}
+      run: dotnet nuget push "*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --source https://nuget.pkg.github.com/${{ github.repository_owner }}

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  Configuration: Release
+  VersionPrefix: 0.0.${{ github.run_number }}
+  VersionSuffix: alpha+${{ github.github.sha }}
+
 jobs:
   build:
     runs-on: windows-latest
@@ -20,7 +25,10 @@ jobs:
       run: dotnet restore
       
     - name: Build
-      run: dotnet build --configuration Release --no-restore -p:Version=0.0.${{ github.run_number }} -p:VersionSuffix=alpha+${{ github.github.sha }}
+      run: dotnet build --configuration Release --no-restore
       
     - name: Test
-      run: dotnet test --no-build --configuration Release
+      run: dotnet test --no-build
+
+    - name: Pack
+      run: dotnet pack --no-build --include-symbols


### PR DESCRIPTION
* Put common msbuild variables (e.g. version, configuration) as Enviornment variables so they're shared across steps with less duplication
* Added nuget pack / publish steps to push to the projects GitHub Packages feed